### PR TITLE
Make ToBitsGadget for FpVar's output constant-length

### DIFF
--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -874,9 +874,10 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
 
     #[tracing::instrument(target = "r1cs")]
     fn to_non_unique_bits_le(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
-        use ark_ff::BitIteratorLE;
+        use algebra::BitIteratorLE;
         match self {
-            Self::Constant(c) => Ok(BitIteratorLE::without_trailing_zeros(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
+                .take((F::Params::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -874,7 +874,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
 
     #[tracing::instrument(target = "r1cs")]
     fn to_non_unique_bits_le(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
-        use algebra::BitIteratorLE;
+        use ark_ff::BitIteratorLE;
         match self {
             Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
                 .take((F::Params::MODULUS_BITS) as usize)


### PR DESCRIPTION
This is related to a Zexe issue https://github.com/scipr-lab/zexe/issues/289

Basically, ToBitsGadget for FpVar may produce shorter output for a constant value, which is undesired for a few reasons.