### PR TITLE
CondSelectGadget for `UInt`s

### DIFF
--- a/src/bits/uint.rs
+++ b/src/bits/uint.rs
@@ -329,6 +329,31 @@ macro_rules! make_uint {
                 }
             }
 
+            impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for $name<ConstraintF> {
+                #[tracing::instrument(target = "r1cs")]
+                fn conditionally_select(
+                    cond: &Boolean<ConstraintF>,
+                    true_value: &Self,
+                    false_value: &Self,
+                ) -> Result<Self, SynthesisError> {
+                    let selected_bits = true_value.bits.iter().zip(&false_value.bits)
+                        .map(|(true_bit, false_bit)| {
+                            cond.select(true_bit, false_bit)
+                        }).collect::<Result<Vec<Boolean<ConstraintF>>, SynthesisError>>()?;
+                    let selected_value = match (cond.value(), true_value.value(), false_value.value()) {
+                        (Ok(true), Err(_), _) => None,
+                        (Ok(true), Ok(v), _) => Some(v),
+                        (Ok(false), _, Err(_)) => None,
+                        (Ok(false), _, Ok(v)) => Some(v),
+                        (Err(_), _, _) => None,
+                    };
+                    Ok(Self {
+                        bits: selected_bits,
+                        value: selected_value,
+                    })
+                }
+            }
+
             impl<ConstraintF: Field> AllocVar<$native, ConstraintF> for $name<ConstraintF> {
                 fn new_variable<T: Borrow<$native>>(
                     cs: impl Into<Namespace<ConstraintF>>,

--- a/src/bits/uint8.rs
+++ b/src/bits/uint8.rs
@@ -401,8 +401,8 @@ mod test {
 
             for x in v.iter().zip(expected_to_be_same.iter()) {
                 match x {
-                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {},
-                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {},
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
                     _ => unreachable!(),
                 }
             }

--- a/src/bits/uint8.rs
+++ b/src/bits/uint8.rs
@@ -297,13 +297,13 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for UInt8<ConstraintF> {
             .zip(&false_value.bits)
             .map(|(t, f)| cond.select(t, f))
             .collect::<Result<Vec<_>, SynthesisError>>()?;
-                    let selected_value = cond.value().ok().and_then(|cond| {
-                    	if cond {
-                    		true_value.value().ok()
-                    	} else {
-                    		false_value.value().ok()
-                    	}
-                    });
+        let selected_value = cond.value().ok().and_then(|cond| {
+            if cond {
+                true_value.value().ok()
+            } else {
+                false_value.value().ok()
+            }
+        });
         Ok(Self {
             bits: selected_bits,
             value: selected_value,
@@ -401,8 +401,8 @@ mod test {
 
             for x in v.iter().zip(expected_to_be_same.iter()) {
                 match x {
-                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
-                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {},
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {},
                     _ => unreachable!(),
                 }
             }

--- a/src/bits/uint8.rs
+++ b/src/bits/uint8.rs
@@ -284,6 +284,33 @@ impl<ConstraintF: Field> EqGadget<ConstraintF> for UInt8<ConstraintF> {
     }
 }
 
+impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for UInt8<ConstraintF> {
+    #[tracing::instrument(target = "r1cs")]
+    fn conditionally_select(
+        cond: &Boolean<ConstraintF>,
+        true_value: &Self,
+        false_value: &Self,
+    ) -> Result<Self, SynthesisError> {
+        let selected_bits = true_value
+            .bits
+            .iter()
+            .zip(&false_value.bits)
+            .map(|(true_bit, false_bit)| cond.select(true_bit, false_bit))
+            .collect::<Result<Vec<Boolean<ConstraintF>>, SynthesisError>>()?;
+        let selected_value = match (cond.value(), true_value.value(), false_value.value()) {
+            (Ok(true), Err(_), _) => None,
+            (Ok(true), Ok(v), _) => Some(v),
+            (Ok(false), _, Err(_)) => None,
+            (Ok(false), _, Ok(v)) => Some(v),
+            (Err(_), _, _) => None,
+        };
+        Ok(Self {
+            bits: selected_bits,
+            value: selected_value,
+        })
+    }
+}
+
 impl<ConstraintF: Field> AllocVar<u8, ConstraintF> for UInt8<ConstraintF> {
     fn new_variable<T: Borrow<u8>>(
         cs: impl Into<Namespace<ConstraintF>>,

--- a/src/bits/uint8.rs
+++ b/src/bits/uint8.rs
@@ -285,7 +285,7 @@ impl<ConstraintF: Field> EqGadget<ConstraintF> for UInt8<ConstraintF> {
 }
 
 impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for UInt8<ConstraintF> {
-    #[tracing::instrument(target = "r1cs")]
+    #[tracing::instrument(target = "r1cs", skip(cond, true_value, false_value))]
     fn conditionally_select(
         cond: &Boolean<ConstraintF>,
         true_value: &Self,
@@ -295,15 +295,15 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for UInt8<ConstraintF> {
             .bits
             .iter()
             .zip(&false_value.bits)
-            .map(|(true_bit, false_bit)| cond.select(true_bit, false_bit))
-            .collect::<Result<Vec<Boolean<ConstraintF>>, SynthesisError>>()?;
-        let selected_value = match (cond.value(), true_value.value(), false_value.value()) {
-            (Ok(true), Err(_), _) => None,
-            (Ok(true), Ok(v), _) => Some(v),
-            (Ok(false), _, Err(_)) => None,
-            (Ok(false), _, Ok(v)) => Some(v),
-            (Err(_), _, _) => None,
-        };
+            .map(|(t, f)| cond.select(t, f))
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+                    let selected_value = cond.value().ok().and_then(|cond| {
+                    	if cond {
+                    		true_value.value().ok()
+                    	} else {
+                    		false_value.value().ok()
+                    	}
+                    });
         Ok(Self {
             bits: selected_bits,
             value: selected_value,


### PR DESCRIPTION
This pull request is copied over from https://github.com/arkworks-rs/snark/pull/312

It implements `CondSelectGadget` for `UInt` constraint variables. `UInt8` is implemented directly, while a macro is included to generate the implementation for `UInt16`, `UInt32`, `UInt64`.

A couple of things for review:
- Is the `tracing` macro being used correctly? Should any of the inputs be skipped?
- Is the behavior for selecting the `value` when the inputs have no values correct?

