### PR TITLE
Reduce allocations in `UInt`s

### DIFF
--- a/src/bits/boolean.rs
+++ b/src/bits/boolean.rs
@@ -829,11 +829,10 @@ impl<F: Field> ToBytesGadget<F> for Boolean<F> {
     /// Outputs `1u8` if `self` is true, and `0u8` otherwise.
     #[tracing::instrument(target = "r1cs")]
     fn to_bytes(&self) -> Result<Vec<UInt8<F>>, SynthesisError> {
-        let mut bits = vec![self.clone()];
-        bits.extend(vec![Boolean::constant(false); 7]);
         let value = self.value().map(u8::from).ok();
-        let byte = UInt8 { bits, value };
-        Ok(vec![byte])
+        let mut bits = [Boolean::FALSE; 8];
+        bits[0] = self.clone();
+        Ok(vec![UInt8 { bits, value }])
     }
 }
 


### PR DESCRIPTION
Reduces the number of allocations required for `UInt`s by moving to arrays.