### PR TITLE
More efficient scalar multiplication for Short Weierstrass curves

### DIFF
--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -228,6 +228,8 @@ where
         // Complete mixed addition formula from Renes-Costello-Batina 2015
         // Algorithm 2
         // (https://eprint.iacr.org/2015/1060).
+        // Below, comments at the end of a line denote the corresponding
+        // step(s) of the algorithm
         //
         // Adapted from code in
         // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs
@@ -347,6 +349,8 @@ where
         // Complete doubling formula from Renes-Costello-Batina 2015
         // Algorithm 3
         // (https://eprint.iacr.org/2015/1060).
+        // Below, comments at the end of a line denote the corresponding
+        // step(s) of the algorithm
         //
         // Adapted from code in
         // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs
@@ -478,7 +482,6 @@ impl_bounded_ops!(
     |mut this: &'a ProjectiveVar<P, F>, mut other: &'a ProjectiveVar<P, F>| {
         // Implement complete addition for Short Weierstrass curves, following
         // the complete addition formula from Renes-Costello-Batina 2015
-        // Algorithm 1
         // (https://eprint.iacr.org/2015/1060).
         //
         // We special case handling of constants to get better constraint weight.
@@ -503,6 +506,8 @@ impl_bounded_ops!(
             // Complete addition formula from Renes-Costello-Batina 2015
             // Algorithm 1
             // (https://eprint.iacr.org/2015/1060).
+            // Below, comments at the end of a line denote the corresponding
+            // step(s) of the algorithm
             //
             // Adapted from code in
             // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -92,14 +92,28 @@ pub trait CurveVar<C: ProjectiveCurve, ConstraintF: Field>:
         &self,
         bits: impl Iterator<Item = &'a Boolean<ConstraintF>>,
     ) -> Result<Self, SynthesisError> {
-        let mut res = Self::zero();
-        let mut multiple = self.clone();
-        for bit in bits {
-            let tmp = res.clone() + &multiple;
-            res = bit.select(&tmp, &res)?;
-            multiple.double_in_place()?;
+        if self.is_constant() {
+            let mut value = self.value().unwrap();
+            let bits_and_multiples = bits.map(|b| {
+                let multiple = value;
+                value.double_in_place();
+                (b, multiple)
+            }).collect::<Vec<_>>();
+            let mut result = self.clone();
+            result.precomputed_base_scalar_mul_le(
+                bits_and_multiples.iter().map(|&(ref b, ref c)| (*b, c))
+            )?;
+            Ok(result)
+        } else {
+            let mut res = Self::zero();
+            let mut multiple = self.clone();
+            for bit in bits {
+                let tmp = res.clone() + &multiple;
+                res = bit.select(&tmp, &res)?;
+                multiple.double_in_place()?;
+            }
+            Ok(res)
         }
-        Ok(res)
     }
 
     /// Computes a `I * self` in place, where `I` is a `Boolean` *little-endian*

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -142,7 +142,7 @@ pub trait CurveVar<C: ProjectiveCurve, ConstraintF: Field>:
         C: 'a,
     {
         // Computes the standard little-endian double-and-add algorithm
-        // (Algorithm 3.27, Guide to Elliptic Curve Cryptography)
+        // (Algorithm 3.26, Guide to Elliptic Curve Cryptography)
 
         // Let `original` be the initial value of `self`.
         for (bit, base) in scalar_bits_with_bases {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -94,14 +94,16 @@ pub trait CurveVar<C: ProjectiveCurve, ConstraintF: Field>:
     ) -> Result<Self, SynthesisError> {
         if self.is_constant() {
             let mut value = self.value().unwrap();
-            let bits_and_multiples = bits.map(|b| {
-                let multiple = value;
-                value.double_in_place();
-                (b, multiple)
-            }).collect::<Vec<_>>();
+            let bits_and_multiples = bits
+                .map(|b| {
+                    let multiple = value;
+                    value.double_in_place();
+                    (b, multiple)
+                })
+                .collect::<Vec<_>>();
             let mut result = self.clone();
             result.precomputed_base_scalar_mul_le(
-                bits_and_multiples.iter().map(|&(ref b, ref c)| (*b, c))
+                bits_and_multiples.iter().map(|&(ref b, ref c)| (*b, c)),
             )?;
             Ok(result)
         } else {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -145,13 +145,15 @@ pub trait CurveVar<C: ProjectiveCurve, ConstraintF: Field>:
         // (Algorithm 3.26, Guide to Elliptic Curve Cryptography)
 
         // Let `original` be the initial value of `self`.
+        let mut result = Self::zero();
         for (bit, base) in scalar_bits_with_bases {
             // Compute `self + 2^i * original`
-            let self_plus_base = self.clone() + *base;
+            let self_plus_base = result.clone() + *base;
             // If `bit == 1`, set self = self + 2^i * original;
             // else, set self = self;
-            *self = bit.borrow().select(&self_plus_base, self)?;
+            result = bit.borrow().select(&self_plus_base, &result)?;
         }
+        *self = result;
         Ok(())
     }
 


### PR DESCRIPTION
- When a group element is a constant, precompute multiples of powers of two, and perform simple conditional additions.
- For short weierstrass curves, addition with a constant now use mixed addition, which results in lower constraint weight.
- For short weierstrass curves, scalar multiplication now uses mixed addition, saving 1 constraint per bit of the scalar (at the cost of a small constant number of constraints to check for edge cases)