### PR TITLE
Better scalar multiplication for Short Weierstrass curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,27 @@
 ## Pending
 
 ### Breaking changes
-- #12 Make FpVar's ToBitsGadget output constant length bit vectors.
+- #12 Make the `ToBitsGadget` impl for `FpVar` output fixed-size
 
 ### Features
 
 
 ### Improvements
 - #5 Speedup BLS-12 pairing
-- #13 Add ToConstraintFieldGadget to ProjectiveVar
-- #15, #16 Allow cs to be none when converting a montgomery point into a twisted edwards point
-- #20 Add conditional select gadget to Uints
-- #21 Add Uint128
+- #13 Add `ToConstraintFieldGadget` to `ProjectiveVar`
+- #15, #16 Allow `cs` to be `None` when converting a Montgomery point into a Twisted Edwards point
+- #20 Add `CondSelectGadget` impl for `UInt`s
+- #21 Add `UInt128`
 - #22 Reduce density of `three_bit_cond_neg_lookup`
-- #23 Reduce allocations in Uints
+- #23 Reduce allocations in `UInt`s
 - #33 Speedup scalar multiplication by a constant
-- #35 Construct a FpVar from bits
-- #36 ImplementToConstraintFieldGadget for `Vec<Uint8>`
+- #35 Construct a `FpVar` from bits
+- #36 Implement `ToConstraintFieldGadget` for `Vec<Uint8>`
+- #40 Faster scalar multiplication for Short Weierstrass curves by relying on affine formulae
 
 ### Bug fixes
-- #8 Fix bug in three_bit_cond_neg_lookup when using a constant lookup bit
-- #9 Fix bug in short weierstrass projective curve point's to_affine method
+- #8 Fix bug in `three_bit_cond_neg_lookup` when using a constant lookup bit
+- #9 Fix bug in `short_weierstrass::ProjectiveVar::to_affine` 
 - #29 Fix `to_non_unique_bytes` for `BLS12::G1Prepared`
 - #34 Fix `mul_by_inverse` for constants
 - #42 Fix regression in `mul_by_inverse` constraint count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - #9 Fix bug in short weierstrass projective curve point's to_affine method
 - #29 Fix `to_non_unique_bytes` for `BLS12::G1Prepared`
 - #34 Fix `mul_by_inverse` for constants
+- #42 Fix regression in `mul_by_inverse` constraint count
 
 ## v0.1.0
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -716,21 +716,6 @@ impl<F: PrimeField> FieldVar<F, F> for FpVar<F> {
         }
     }
 
-    /// Returns (self / denominator), but requires fewer constraints than
-    /// self * denominator.inverse()
-    /// It is up to the caller to ensure that denominator is non-zero,
-    /// since in that case the result is unconstrained.
-    #[tracing::instrument(target = "r1cs")]
-    fn mul_by_inverse(&self, denominator: &Self) -> Result<Self, SynthesisError> {
-        use FpVar::*;
-        match (self, denominator) {
-            (Constant(s), Constant(d)) => Ok(Constant(*s / *d)),
-            (Var(s), Constant(d)) => Ok(Var(s.mul_constant(d.inverse().get()?))),
-            (Constant(s), Var(d)) => Ok(Var(d.inverse()?.mul_constant(*s))),
-            (Var(s), Var(d)) => Ok(Var(d.inverse()?.mul(s))),
-        }
-    }
-
     #[tracing::instrument(target = "r1cs")]
     fn frobenius_map(&self, power: usize) -> Result<Self, SynthesisError> {
         match self {

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -21,6 +21,8 @@ pub mod mnt4;
 ///  family of bilinear groups.
 pub mod mnt6;
 
+mod non_zero_affine;
+
 /// An implementation of arithmetic for Short Weierstrass curves that relies on
 /// the complete formulae derived in the paper of
 /// [[Renes, Costello, Batina 2015]](https://eprint.iacr.org/2015/1060).

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -266,14 +266,14 @@ where
     }
 
     /// Computes a scalar multiplication with a little-endian scalar of size `P::ScalarField::MODULUS_BITS`.
-    // #[tracing::instrument(target = "r1cs", skip(self, non_zero_self, mul_result, multiple_power_of_two, bits))]
+    #[tracing::instrument(target = "r1cs", skip(self, mul_result, multiple_of_power_of_two, bits))]
     fn fixed_scalar_mul_le(
         &self,
         mul_result: &mut Self,
         multiple_of_power_of_two: &mut NonZeroAffineVar<P, F>,
         bits: &[&Boolean<<P::BaseField as Field>::BasePrimeField>],
     ) -> Result<(), SynthesisError> {
-        let scalar_modulus_bits = <P::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
+        let scalar_modulus_bits = <<P::ScalarField as PrimeField>::Params>::MODULUS_BITS as usize;
 
         assert!(scalar_modulus_bits >= bits.len());
         let split_len = ark_std::cmp::min(scalar_modulus_bits - 2, bits.len());
@@ -466,7 +466,7 @@ where
 
     /// Computes `bits * self`, where `bits` is a little-endian
     /// `Boolean` representation of a scalar.
-    // #[tracing::instrument(target = "r1cs", skip(bits))]
+    #[tracing::instrument(target = "r1cs", skip(bits))]
     fn scalar_mul_le<'a>(
         &self,
         bits: impl Iterator<Item = &'a Boolean<<P::BaseField as Field>::BasePrimeField>>,
@@ -486,7 +486,7 @@ where
         if bits.len() == 0 {
             return Ok(Self::zero());
         }
-        let scalar_modulus_bits = <P::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
+        let scalar_modulus_bits = <<P::ScalarField as PrimeField>::Params>::MODULUS_BITS as usize;
         let mut mul_result = Self::zero();
         let mut power_of_two_times_self = non_zero_self;
         // We chunk up `bits` into `p`-sized chunks.

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -473,7 +473,7 @@ where
     ) -> Result<Self, SynthesisError> {
         if self.is_constant() {
             if self.value().unwrap().is_zero() {
-                return Ok(self.clone())
+                return Ok(self.clone());
             }
         }
         let self_affine = self.to_affine()?;
@@ -512,7 +512,9 @@ where
         B: Borrow<Boolean<<P::BaseField as Field>::BasePrimeField>>,
     {
         // We just ignore the provided bases and use the faster scalar multiplication.
-        let (bits, bases): (Vec<_>, Vec<_>) = scalar_bits_with_bases.map(|(b, c)| (b.borrow().clone(), *c)).unzip();
+        let (bits, bases): (Vec<_>, Vec<_>) = scalar_bits_with_bases
+            .map(|(b, c)| (b.borrow().clone(), *c))
+            .unzip();
         let base = bases[0];
         *self = Self::constant(base).scalar_mul_le(bits.iter())?;
         Ok(())

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -282,10 +282,10 @@ where
         // (Algorithm 3.26, Guide to Elliptic Curve Cryptography)
         //
         // We rely on *incomplete* affine formulae for partially computing this.
-        // However, we avoid exceptional edge cases because we partition the scalar 
-        // into two chunks: one guaranteed to be less than p - 2, and the rest. 
+        // However, we avoid exceptional edge cases because we partition the scalar
+        // into two chunks: one guaranteed to be less than p - 2, and the rest.
         // We only use incomplete formulae for the first chunk, which means we avoid exceptions:
-        // 
+        //
         // `add_unchecked(a, b)` is incomplete when either `b.is_zero()`, or when
         // `b = ±a`. During scalar multiplication, we don't hit either case:
         // * `b = ±a`: `b = accumulator = k * a`, where `2 <= k < p - 1`.
@@ -297,12 +297,12 @@ where
 
         // Unlike normal double-and-add, here we start off with a non-zero `accumulator`,
         // because `NonZeroAffineVar::add_unchecked` doesn't support addition with `zero`.
-        // In more detail, we initialize `accumulator` to be the initial value of 
+        // In more detail, we initialize `accumulator` to be the initial value of
         // `multiple_of_power_of_two`. This ensures that all unchecked additions of `accumulator`
         // with later values of `multiple_of_power_of_two` are safe.
         // However, to do this correctly, we need to perform two steps:
-        // * We must skip the LSB, and instead proceed assuming that it was 1. Later, we will 
-        //   conditionally subtract the initial value of `accumulator`: 
+        // * We must skip the LSB, and instead proceed assuming that it was 1. Later, we will
+        //   conditionally subtract the initial value of `accumulator`:
         //     if LSB == 0: subtract initial_acc_value; else, subtract 0.
         // * Because we are assuming the first bit, we must double `multiple_of_power_of_two`.
 
@@ -507,11 +507,7 @@ where
             let mut power_of_two_times_self = non_zero_self;
             // We chunk up `bits` into `p`-sized chunks.
             for bits in bits.chunks(scalar_modulus_bits) {
-                self.fixed_scalar_mul_le(
-                    &mut mul_result,
-                    &mut power_of_two_times_self,
-                    bits,
-                )?;
+                self.fixed_scalar_mul_le(&mut mul_result, &mut power_of_two_times_self, bits)?;
             }
 
             // The foregoing algorithms rely on mixed/incomplete addition, and so do not

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -266,7 +266,10 @@ where
     }
 
     /// Computes a scalar multiplication with a little-endian scalar of size `P::ScalarField::MODULUS_BITS`.
-    #[tracing::instrument(target = "r1cs", skip(self, mul_result, multiple_of_power_of_two, bits))]
+    #[tracing::instrument(
+        target = "r1cs",
+        skip(self, mul_result, multiple_of_power_of_two, bits)
+    )]
     fn fixed_scalar_mul_le(
         &self,
         mul_result: &mut Self,

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -4,7 +4,7 @@ use super::*;
 #[derive(Derivative)]
 #[derivative(Debug, Clone)]
 #[must_use]
-pub struct AffineVar<
+pub struct NonZeroAffineVar<
     P: SWModelParameters,
     F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
 > where
@@ -18,7 +18,7 @@ pub struct AffineVar<
     _params: PhantomData<P>,
 }
 
-impl<P, F> AffineVar<P, F>
+impl<P, F> NonZeroAffineVar<P, F>
 where
     P: SWModelParameters,
     F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
@@ -32,13 +32,119 @@ where
         }
     }
 
-    /// Returns the value assigned to `self` in the underlying
-    /// constraint system.
-    pub(crate) fn value(&self) -> Result<SWAffine<P>, SynthesisError> {
-        Ok(SWAffine::new(
-            self.x.value()?,
-            self.y.value()?,
-            false,
-        ))
+    /// Converts self into a non-zero projective point.
+    #[tracing::instrument(target = "r1cs", skip(self))]
+    pub(crate) fn into_projective(&self) -> ProjectiveVar<P, F> {
+        ProjectiveVar::new(self.x.clone(), self.y.clone(), F::one())
+    }
+
+    /// Performs an addition without checking that other != ±self.
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
+    pub(crate) fn add_unchecked(&self, other: &Self) -> Result<Self, SynthesisError> {
+        if [self, other].is_constant() {
+            let result =
+                (self.value()?.into_projective() + other.value()?.into_projective()).into_affine();
+            // Panic is the result is zero.
+            assert!(!result.is_zero());
+            Ok(Self::new(F::constant(result.x), F::constant(result.y)))
+        } else {
+            let cs = [self, other].cs();
+            let (x1, y1) = (&self.x, &self.y);
+            let (x2, y2) = (&other.x, &other.y);
+            // Then,
+            // slope lambda := (y2 - y1)/(x2 - x1);
+            // x3 = lambda^2 - x1 - x2;
+            // y3 = lambda * (x1 - x3) - y1
+            let numerator = y2 - y1;
+            let denominator = x2 - x1;
+            let lambda = F::new_witness(ns!(cs, "lambda"), || {
+                Ok(numerator.value()?
+                    * &denominator
+                        .value()?
+                        .inverse()
+                        .unwrap_or(P::BaseField::zero()))
+            })?;
+            lambda.mul_equals(&denominator, &numerator)?;
+            let x3 = lambda.square()? - x1 - x2;
+            let y3 = lambda * &(x1 - &x3) - y1;
+            Ok(Self::new(x3, y3))
+        }
+    }
+
+    /// Doubles `self`
+    #[tracing::instrument(target = "r1cs", skip(self))]
+    pub(crate) fn double(&self) -> Result<Self, SynthesisError> {
+        if [self].is_constant() {
+            let result = self.value()?.into_projective().double().into_affine();
+            // Panic is the result is zero.
+            assert!(!result.is_zero());
+            Ok(Self::new(F::constant(result.x), F::constant(result.y)))
+        } else {
+            let cs = self.cs();
+            let (x1, y1) = (&self.x, &self.y);
+            let x1_sqr = x1.square()?;
+            let numerator = x1_sqr.double()? + &x1_sqr + P::COEFF_A;
+            let denominator = y1.double()?;
+            // Then,
+            // slope lambda := (3 * x1^2 + a) / y1·;
+            // x3 = lambda^2 - 2x1
+            // y3 = lambda * (x1 - x3) - y1
+            let lambda = F::new_witness(ns!(cs, "lambda"), || {
+                Ok(numerator.value()?
+                    * &denominator
+                        .value()?
+                        .inverse()
+                        .unwrap_or(P::BaseField::zero()))
+            })?;
+            lambda.mul_equals(&denominator, &numerator)?;
+
+            let x3 = lambda.square()? - x1.double()?;
+            let y3 = lambda * &(x1 - &x3) - y1;
+            Ok(Self::new(x3, y3))
+        }
+    }
+
+    /// Doubles `self` in place.
+    #[tracing::instrument(target = "r1cs", skip(self))]
+    pub(crate) fn double_in_place(&mut self) -> Result<(), SynthesisError> {
+        *self = self.double()?;
+        Ok(())
+    }
+}
+
+impl<P, F> R1CSVar<<P::BaseField as Field>::BasePrimeField> for NonZeroAffineVar<P, F>
+where
+    P: SWModelParameters,
+    F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+{
+    type Value = SWAffine<P>;
+
+    fn cs(&self) -> ConstraintSystemRef<<P::BaseField as Field>::BasePrimeField> {
+        self.x.cs().or(self.y.cs())
+    }
+
+    fn value(&self) -> Result<SWAffine<P>, SynthesisError> {
+        Ok(SWAffine::new(self.x.value()?, self.y.value()?, false))
+    }
+}
+
+impl<P, F> CondSelectGadget<<P::BaseField as Field>::BasePrimeField> for NonZeroAffineVar<P, F>
+where
+    P: SWModelParameters,
+    F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+{
+    #[inline]
+    #[tracing::instrument(target = "r1cs")]
+    fn conditionally_select(
+        cond: &Boolean<<P::BaseField as Field>::BasePrimeField>,
+        true_value: &Self,
+        false_value: &Self,
+    ) -> Result<Self, SynthesisError> {
+        let x = cond.select(&true_value.x, &false_value.x)?;
+        let y = cond.select(&true_value.y, &false_value.y)?;
+
+        Ok(Self::new(x, y))
     }
 }

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -69,7 +69,7 @@ where
         }
     }
 
-    /// Doubles `self`. As this is a prime order curve point, 
+    /// Doubles `self`. As this is a prime order curve point,
     /// the output is guaranteed to not be the point at infinity.
     #[tracing::instrument(target = "r1cs", skip(self))]
     pub(crate) fn double(&self) -> Result<Self, SynthesisError> {

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -44,8 +44,6 @@ where
         if [self, other].is_constant() {
             let result =
                 (self.value()?.into_projective() + other.value()?.into_projective()).into_affine();
-            // Panic is the result is zero.
-            assert!(!result.is_zero());
             Ok(Self::new(F::constant(result.x), F::constant(result.y)))
         } else {
             let cs = [self, other].cs();
@@ -76,7 +74,7 @@ where
     pub(crate) fn double(&self) -> Result<Self, SynthesisError> {
         if [self].is_constant() {
             let result = self.value()?.into_projective().double().into_affine();
-            // Panic is the result is zero.
+            // Panic if the result is zero.
             assert!(!result.is_zero());
             Ok(Self::new(F::constant(result.x), F::constant(result.y)))
         } else {

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -46,10 +46,6 @@ where
                 (self.value()?.into_projective() + other.value()?.into_projective()).into_affine();
             Ok(Self::new(F::constant(result.x), F::constant(result.y)))
         } else {
-<<<<<<< HEAD
-=======
-            let cs = [self, other].cs();
->>>>>>> 52470fd85cfb987ad0fcb40f04733c9d08aa7ff8
             let (x1, y1) = (&self.x, &self.y);
             let (x2, y2) = (&other.x, &other.y);
             // Then,

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -1,0 +1,44 @@
+use super::*;
+/// An affine representation of a curve point that is guaranteed
+/// to *not* be the point at infinity.
+#[derive(Derivative)]
+#[derivative(Debug, Clone)]
+#[must_use]
+pub struct AffineVar<
+    P: SWModelParameters,
+    F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+> where
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+{
+    /// The x-coordinate.
+    pub x: F,
+    /// The y-coordinate.
+    pub y: F,
+    #[derivative(Debug = "ignore")]
+    _params: PhantomData<P>,
+}
+
+impl<P, F> AffineVar<P, F>
+where
+    P: SWModelParameters,
+    F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+{
+    pub(crate) fn new(x: F, y: F) -> Self {
+        Self {
+            x,
+            y,
+            _params: PhantomData,
+        }
+    }
+
+    /// Returns the value assigned to `self` in the underlying
+    /// constraint system.
+    pub(crate) fn value(&self) -> Result<SWAffine<P>, SynthesisError> {
+        Ok(SWAffine::new(
+            self.x.value()?,
+            self.y.value()?,
+            false,
+        ))
+    }
+}

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -1,5 +1,5 @@
 use super::*;
-/// An affine representation of a curve point that is guaranteed
+/// An affine representation of a prime order curve point that is guaranteed
 /// to *not* be the point at infinity.
 #[derive(Derivative)]
 #[derivative(Debug, Clone)]
@@ -69,7 +69,8 @@ where
         }
     }
 
-    /// Doubles `self`
+    /// Doubles `self`. As this is a prime order curve point, 
+    /// the output is guaranteed to not be the point at infinity.
     #[tracing::instrument(target = "r1cs", skip(self))]
     pub(crate) fn double(&self) -> Result<Self, SynthesisError> {
         if [self].is_constant() {

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -548,7 +548,6 @@ where
                 let y = F::two_bit_lookup(&bits, &y_s)?;
                 *self += Self::new(x, y);
             } else if bits.len() == 1 {
-                // println!("Here");
                 let bit = &bits[0];
                 let tmp = &*self + multiples[0];
                 *self = bit.select(&tmp, &*self)?;

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -92,6 +92,9 @@ pub trait CurveVar<C: ProjectiveCurve, ConstraintF: Field>:
         &self,
         bits: impl Iterator<Item = &'a Boolean<ConstraintF>>,
     ) -> Result<Self, SynthesisError> {
+        // TODO: in the constant case we should call precomputed_scalar_mul_le,
+        // but rn there's a bug when doing this with TE curves.
+
         // Computes the standard little-endian double-and-add algorithm
         // (Algorithm 3.26, Guide to Elliptic Curve Cryptography)
         let mut res = Self::zero();


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Uses affine oeprations, but in a way that is guaranteed to be safe. Tested against PR https://github.com/arkworks-rs/curves/pull/37, which tests scalar multiplication more comprehensively.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
