### PR TITLE
Make `mul_by_inverse` use one constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - #9 Fix bug in short weierstrass projective curve point's to_affine method
 - #29 Fix `to_non_unique_bytes` for `BLS12::G1Prepared`
 - #34 Fix `mul_by_inverse` for constants
+- #42 Fix regression in `mul_by_inverse` constraint count
 
 ## v0.1.0
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -727,7 +727,11 @@ impl<F: PrimeField> FieldVar<F, F> for FpVar<F> {
             (Constant(s), Constant(d)) => Ok(Constant(*s / *d)),
             (Var(s), Constant(d)) => Ok(Var(s.mul_constant(d.inverse().get()?))),
             (Constant(s), Var(d)) => Ok(Var(d.inverse()?.mul_constant(*s))),
-            (Var(s), Var(d)) => Ok(Var(d.inverse()?.mul(s))),
+            (Var(s), Var(d)) => Self::new_witness(self.cs(), || {
+                let denominator_inv_native = denominator.value()?.inverse().get()?;
+                let result = self.value()? * &denominator_inv_native;
+                Ok(result)
+            }),
         }
     }
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -727,7 +727,7 @@ impl<F: PrimeField> FieldVar<F, F> for FpVar<F> {
             (Constant(s), Constant(d)) => Ok(Constant(*s / *d)),
             (Var(s), Constant(d)) => Ok(Var(s.mul_constant(d.inverse().get()?))),
             (Constant(s), Var(d)) => Ok(Var(d.inverse()?.mul_constant(*s))),
-            (Var(s), Var(d)) => Self::new_witness(self.cs(), || {
+            (Var(_s), Var(_d)) => Self::new_witness(self.cs(), || {
                 let denominator_inv_native = denominator.value()?.inverse().get()?;
                 let result = self.value()? * &denominator_inv_native;
                 Ok(result)

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -716,30 +716,6 @@ impl<F: PrimeField> FieldVar<F, F> for FpVar<F> {
         }
     }
 
-    /// Returns (self / denominator), but requires fewer constraints than
-    /// self * denominator.inverse()
-    /// It is up to the caller to ensure that denominator is non-zero,
-    /// since in that case the result is unconstrained.
-    #[tracing::instrument(target = "r1cs")]
-    fn mul_by_inverse(&self, denominator: &Self) -> Result<Self, SynthesisError> {
-        use FpVar::*;
-        match (self, denominator) {
-            (Constant(s), Constant(d)) => Ok(Constant(*s / *d)),
-            (Var(s), Constant(d)) => Ok(Var(s.mul_constant(d.inverse().get()?))),
-            (Constant(s), Var(d)) => Ok(Var(d.inverse()?.mul_constant(*s))),
-            (Var(s), Var(d)) => {
-                let d_inv = Self::new_witness(self.cs(), || {
-                    let d_inv = d.value()?.inverse().ok_or(F::zero());
-                    match d_inv {
-                        Ok(v) => Ok(self.value()? * &v),
-                        Err(v) => Ok(v),
-                    }
-                })?;
-                Ok(s.mul(d_inv))
-            }
-        }
-    }
-
     #[tracing::instrument(target = "r1cs")]
     fn frobenius_map(&self, power: usize) -> Result<Self, SynthesisError> {
         match self {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Make mul_by_inverse take 1 constraint for FpVar

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
