### PR TITLE
Improve handling of constant bits in scalar mul for SW curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Pending
 
 ### Breaking changes
-- #12 Make the `ToBitsGadget` impl for `FpVar` output fixed-size
+- #12 Make the output of the `ToBitsGadget` impl for `FpVar` fixed-size
 
 ### Features
 
@@ -17,7 +17,7 @@
 - #33 Speedup scalar multiplication by a constant
 - #35 Construct a `FpVar` from bits
 - #36 Implement `ToConstraintFieldGadget` for `Vec<Uint8>`
-- #40 Faster scalar multiplication for Short Weierstrass curves by relying on affine formulae
+- #40, #43 Faster scalar multiplication for Short Weierstrass curves by relying on affine formulae
 
 ### Bug fixes
 - #8 Fix bug in `three_bit_cond_neg_lookup` when using a constant lookup bit

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -317,8 +317,10 @@ where
 
         // As mentioned, we will skip the LSB, and will later handle it via a conditional subtraction.
         for bit in affine_bits.iter().skip(1) {
-            if bit.is_constant() && *bit == &Boolean::TRUE {
-                accumulator = accumulator.add_unchecked(&multiple_of_power_of_two)?;
+            if bit.is_constant() {
+                if *bit == &Boolean::TRUE {
+                    accumulator = accumulator.add_unchecked(&multiple_of_power_of_two)?;
+                }
             } else {
                 let temp = accumulator.add_unchecked(&multiple_of_power_of_two)?;
                 accumulator = bit.select(&temp, &accumulator)?;
@@ -336,8 +338,10 @@ where
 
         // Now, let's finish off the rest of the bits using our complete formulae
         for bit in proj_bits {
-            if bit.is_constant() && *bit == &Boolean::TRUE {
-                *mul_result += &multiple_of_power_of_two.into_projective();
+            if bit.is_constant() {
+                if *bit == &Boolean::TRUE {
+                    *mul_result += &multiple_of_power_of_two.into_projective();
+                }
             } else {
                 let temp = &*mul_result + &multiple_of_power_of_two.into_projective();
                 *mul_result = bit.select(&temp, &mul_result)?;
@@ -505,7 +509,10 @@ where
             // Skip leading zeros, if they are constants.
             .skip_while(|b| b.is_constant() && (b.value().unwrap() == false))
             .collect();
+        // After collecting we are in big-endian form; we have to reverse to get back to
+        // little-endian.
         bits.reverse();
+
         let scalar_modulus_bits = <P::ScalarField as PrimeField>::size_in_bits();
         let mut mul_result = Self::zero();
         let mut power_of_two_times_self = non_zero_self;

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -505,6 +505,7 @@ where
             // Skip leading zeros, if they are constants.
             .skip_while(|b| b.is_constant() && (b.value().unwrap() == false))
             .collect();
+        bits.reverse();
         let scalar_modulus_bits = <P::ScalarField as PrimeField>::size_in_bits();
         let mut mul_result = Self::zero();
         let mut power_of_two_times_self = non_zero_self;

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -500,7 +500,11 @@ where
         // Skip leading zeros.
         if bits.is_constant() {
             // We iterate from the MSB down.
-            bits = bits.into_iter().rev().skip_while(|b| !b.value().unwrap()).collect();
+            bits = bits
+                .into_iter()
+                .rev()
+                .skip_while(|b| !b.value().unwrap())
+                .collect();
         }
         let scalar_modulus_bits = <P::ScalarField as PrimeField>::size_in_bits();
         let mut mul_result = Self::zero();

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -497,15 +497,14 @@ where
         if bits.len() == 0 {
             return Ok(Self::zero());
         }
-        // Skip leading zeros.
-        if bits.is_constant() {
+        // Remove unnecessary constant zeros in the most-significant positions.
+        bits = bits
+            .into_iter()
             // We iterate from the MSB down.
-            bits = bits
-                .into_iter()
-                .rev()
-                .skip_while(|b| !b.value().unwrap())
-                .collect();
-        }
+            .rev()
+            // Skip leading zeros, if they are constants.
+            .skip_while(|b| b.is_constant() && (b.value().unwrap() == false))
+            .collect();
         let scalar_modulus_bits = <P::ScalarField as PrimeField>::size_in_bits();
         let mut mul_result = Self::zero();
         let mut power_of_two_times_self = non_zero_self;

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -74,7 +74,7 @@ where
             let (x1, y1) = (&self.x, &self.y);
             let x1_sqr = x1.square()?;
             // Then,
-            // tangent lambda := (3 * x1^2 + a) / y1·;
+            // tangent lambda := (3 * x1^2 + a) / (2 * y1);
             // x3 = lambda^2 - 2x1
             // y3 = lambda * (x1 - x3) - y1
             let numerator = x1_sqr.double()? + &x1_sqr + P::COEFF_A;
@@ -83,6 +83,41 @@ where
             let x3 = lambda.square()? - x1.double()?;
             let y3 = lambda * &(x1 - &x3) - y1;
             Ok(Self::new(x3, y3))
+        }
+    }
+
+    /// Computes `(self + other) + self`. This method requires only 5 constraints, 
+    /// is less than the 7 required when computing via `self.double() + other`.
+    /// 
+    /// This follows the formulae from [\[ELM03\]](https://arxiv.org/abs/math/0208038).
+    #[tracing::instrument(target = "r1cs", skip(self))]
+    pub(crate) fn double_and_add(
+        &self,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if [self].is_constant() || other.is_constant() {
+            self.double()?.add_unchecked(other)
+        } else {
+            let (x1, y1) = (&self.x, &self.y);
+            let (x2, y2) = (&other.x, &other.y);
+
+            // Calculate self + other:
+            // slope lambda := (y2 - y1)/(x2 - x1);
+            // x3 = lambda^2 - x1 - x2;
+            // y3 = lambda * (x1 - x3) - y1
+            let numerator = y2 - y1;
+            let denominator = x2 - x1;
+            let lambda_1 = numerator.mul_by_inverse(&denominator)?;
+
+            let x3 = lambda_1.square()? - x1 - x2;
+
+
+            // Calculate final addition slope:
+            let lambda_2 = (lambda_1 + y1.double()?.mul_by_inverse(&(&x3 - x1))?).negate()?;
+
+            let x4 = lambda_2.square()? - x1 - x3;
+            let y4 = lambda_2 * &(x1 - &x4) - y1;
+            Ok(Self::new(x4, y4))
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Some small improvements for scalar multiplication. In particular, there are two changes:

* We add a `double_and_add` method that computes `2 * self + other` more efficiently than just doubling + addition; this is not used anywhere yet, but I am planning on fiddling with it to see if we can leverage it somehow. (See https://github.com/zcash/zcash/issues/3924 for details)

* We handle constant scalars better:
	* We skip the most-significant constant zeroes to avoid unnecessary doubling
	* When intermediate bits of the scalar are constants, instead of conditionally adding, we directly use the value of the bit to decide whether to add or not.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
