### PR TITLE
Add Mux gadget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 - #12 Make the output of the `ToBitsGadget` impl for `FpVar` fixed-size
-
+- #48 Add `Clone` trait bound to `CondSelectGadget`.
 ### Features
 
 
@@ -18,6 +18,7 @@
 - #35 Construct a `FpVar` from bits
 - #36 Implement `ToConstraintFieldGadget` for `Vec<Uint8>`
 - #40, #43 Faster scalar multiplication for Short Weierstrass curves by relying on affine formulae
+- #46 Add mux gadget as an auto-impl in `CondSelectGadget` to support random access of an array
 
 ### Bug fixes
 - #8 Fix bug in `three_bit_cond_neg_lookup` when using a constant lookup bit

--- a/src/select.rs
+++ b/src/select.rs
@@ -37,10 +37,11 @@ where
         assert!(m.is_power_of_two());
         assert_eq!(1 << n, m);
 
-        // Assert `position` is not empty
         let mut cur_mux_values = values.to_vec();
 
         // Traverse the evaluation tree from bottom to top in level order traversal.
+        // This is method 5.1 from https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf
+        // TODO: Add method 5.2/5.3
         for i in 0..n {
             // Size of current layer.
             let cur_size = 1 << (n - i);

--- a/src/select.rs
+++ b/src/select.rs
@@ -53,6 +53,7 @@ where
                     &position[n - 1 - i],
                     // true case
                     &cur_mux_values[j + 1],
+                    // false case
                     &cur_mux_values[j],
                 )?;
                 next_mux_values.push(cur);

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use ark_ff::Field;
 use ark_relations::r1cs::SynthesisError;
-
+use ark_std::vec::Vec;
 /// Generates constraints for selecting between one of two values.
 pub trait CondSelectGadget<ConstraintF: Field>
 where


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In response to issue alexchmit/perfect-constraints#5. this PR moves `mux` to an auto-impl on CondSelectGadget. By adding new API, this crate can support random access of a vector of size that is power of two.

### Some Details

Add an auto-impl at CondSelectGadget (https://github.com/arkworks-rs/r1cs-std/blob/master/src/select.rs#L6). The new API is conditionally_select_power_of_two_vector(position: &[Bool], values: &[Self]) -> Result<Self, SynthesisError>, and the main code reuses existing logic in https://github.com/alexchmit/perfect-constraints/blob/master/fractal/src/algebra/mux.rs#L5

This PR also adds some unit tests. 

closes: #46

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
