### PR TITLE
replace `rand` with `ark_std::rand` and drop `rand_xorshift`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ num-bigint = {version = "0.3", default-features = false }
 num-traits = {version = "0.2", default-features = false }
 
 [dev-dependencies]
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 ark-test-curves = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = ["bls12_381_scalar_field", "mnt4_753_scalar_field"] }
 
 [features]

--- a/src/bits/boolean.rs
+++ b/src/bits/boolean.rs
@@ -959,8 +959,6 @@ mod test {
     use ark_ff::{BitIteratorBE, BitIteratorLE, Field, One, PrimeField, UniformRand, Zero};
     use ark_relations::r1cs::{ConstraintSystem, Namespace, SynthesisError};
     use ark_test_curves::bls12_381::Fr;
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_boolean_to_byte() -> Result<(), SynthesisError> {
@@ -1634,7 +1632,7 @@ mod test {
 
     #[test]
     fn test_smaller_than_or_equal_to() -> Result<(), SynthesisError> {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
         for _ in 0..1000 {
             let mut r = Fr::rand(&mut rng);
             let mut s = Fr::rand(&mut rng);
@@ -1688,7 +1686,7 @@ mod test {
             assert!(!cs.is_satisfied().unwrap());
         }
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
 
         for _ in 0..1000 {
             let r = Fr::rand(&mut rng);

--- a/src/bits/uint.rs
+++ b/src/bits/uint.rs
@@ -386,12 +386,11 @@ macro_rules! make_uint {
                 use crate::{bits::boolean::Boolean, prelude::*, Vec};
                 use ark_test_curves::mnt4_753::Fr;
                 use ark_relations::r1cs::{ConstraintSystem, SynthesisError};
-                use rand::{Rng, SeedableRng};
-                use rand_xorshift::XorShiftRng;
+                use ark_std::rand::Rng;
 
                 #[test]
                 fn test_from_bits() -> Result<(), SynthesisError> {
-                    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+                    let mut rng = ark_std::test_rng();
 
                     for _ in 0..1000 {
                         let v = (0..$size)
@@ -425,7 +424,7 @@ macro_rules! make_uint {
                 #[test]
                 fn test_xor() -> Result<(), SynthesisError> {
                     use Boolean::*;
-                    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+                    let mut rng = ark_std::test_rng();
 
                     for _ in 0..1000 {
                         let cs = ConstraintSystem::<Fr>::new_ref();
@@ -462,7 +461,7 @@ macro_rules! make_uint {
 
                 #[test]
                 fn test_addmany_constants() -> Result<(), SynthesisError> {
-                    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+                    let mut rng = ark_std::test_rng();
 
                     for _ in 0..1000 {
                         let cs = ConstraintSystem::<Fr>::new_ref();
@@ -496,7 +495,7 @@ macro_rules! make_uint {
 
                 #[test]
                 fn test_addmany() -> Result<(), SynthesisError> {
-                    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+                    let mut rng = ark_std::test_rng();
 
                     for _ in 0..1000 {
                         let cs = ConstraintSystem::<Fr>::new_ref();
@@ -534,7 +533,7 @@ macro_rules! make_uint {
 
                 #[test]
                 fn test_rotr() -> Result<(), SynthesisError> {
-                    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+                    let mut rng = ark_std::test_rng();
 
                     let mut num = rng.gen();
 

--- a/src/bits/uint8.rs
+++ b/src/bits/uint8.rs
@@ -365,10 +365,9 @@ mod test {
     use crate::{prelude::*, ToConstraintFieldGadget, Vec};
     use ark_ff::{FpParameters, PrimeField, ToConstraintField};
     use ark_relations::r1cs::{ConstraintSystem, SynthesisError};
+    use ark_std::rand::distributions::Uniform;
+    use ark_std::rand::Rng;
     use ark_test_curves::bls12_381::Fr;
-    use rand::distributions::Uniform;
-    use rand::{Rng, SeedableRng};
-    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_uint8_from_bits_to_bits() -> Result<(), SynthesisError> {
@@ -407,7 +406,7 @@ mod test {
 
     #[test]
     fn test_uint8_from_bits() -> Result<(), SynthesisError> {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
 
         for _ in 0..1000 {
             let v = (0..8)
@@ -438,7 +437,7 @@ mod test {
 
     #[test]
     fn test_uint8_xor() -> Result<(), SynthesisError> {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
 
         for _ in 0..1000 {
             let cs = ConstraintSystem::<Fr>::new_ref();
@@ -475,7 +474,7 @@ mod test {
 
     #[test]
     fn test_uint8_to_constraint_field() -> Result<(), SynthesisError> {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
         let max_size = (<Fr as PrimeField>::Params::CAPACITY / 8) as usize;
 
         let modes = [Input, Witness, Constant];
@@ -506,7 +505,7 @@ mod test {
 
     #[test]
     fn test_uint8_random_access() {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
 
         for _ in 0..100 {
             let cs = ConstraintSystem::<Fr>::new_ref();

--- a/src/fields/fp/cmp.rs
+++ b/src/fields/fp/cmp.rs
@@ -153,9 +153,8 @@ impl<F: PrimeField> FpVar<F> {
 
 #[cfg(test)]
 mod test {
-    use rand::{Rng, SeedableRng};
-    use rand_xorshift::XorShiftRng;
-    use std::cmp::Ordering;
+    use ark_std::cmp::Ordering;
+    use ark_std::rand::Rng;
 
     use crate::{alloc::AllocVar, fields::fp::FpVar};
     use ark_ff::{PrimeField, UniformRand};
@@ -164,10 +163,7 @@ mod test {
 
     #[test]
     fn test_cmp() {
-        let mut rng = &mut XorShiftRng::from_seed([
-            0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc,
-            0x06, 0x54,
-        ]);
+        let mut rng = ark_std::test_rng();
         fn rand_in_range<R: Rng>(rng: &mut R) -> Fr {
             let pminusonedivtwo: Fr = Fr::modulus_minus_one_div_two().into();
             let mut r;


### PR DESCRIPTION
## Description

This PR lets `r1cs_std` directly uses `ark_std::rand`. Also, this PR replaces the use of XorShiftRng with the standard test_rng.

closes: #30 , #31 

---

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
