### PR TITLE
fixed link format

### DIFF
--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -10,22 +10,22 @@ use non_zero_affine::NonZeroAffineVar;
 use crate::{fields::fp::FpVar, prelude::*, ToConstraintFieldGadget, Vec};
 
 /// This module provides a generic implementation of G1 and G2 for
-/// the [\[BLS12]\](https://eprint.iacr.org/2002/088.pdf) family of bilinear groups.
+/// the [\[BLS12]\](<https://eprint.iacr.org/2002/088.pdf>) family of bilinear groups.
 pub mod bls12;
 
 /// This module provides a generic implementation of G1 and G2 for
-/// the [\[MNT4]\](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf)
+/// the [\[MNT4]\](<https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf>)
 ///  family of bilinear groups.
 pub mod mnt4;
 /// This module provides a generic implementation of G1 and G2 for
-/// the [\[MNT6]\](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf)
+/// the [\[MNT6]\](<https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf>)
 ///  family of bilinear groups.
 pub mod mnt6;
 
 mod non_zero_affine;
 /// An implementation of arithmetic for Short Weierstrass curves that relies on
 /// the complete formulae derived in the paper of
-/// [[Renes, Costello, Batina 2015]](https://eprint.iacr.org/2015/1060).
+/// [[Renes, Costello, Batina 2015]](<https://eprint.iacr.org/2015/1060>).
 #[derive(Derivative)]
 #[derivative(Debug, Clone)]
 #[must_use]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Use an automatic link instead.

When I build the doc with `cargo doc --open` (cargo 1.51.0-nightly (783bc43c6 2021-01-20)), I got err msg like:

```
error: this URL is not a hyperlink
  --> src/groups/curves/short_weierstrass/mod.rs:13:21
   |
13 | /// the [\[BLS12]\](https://eprint.iacr.org/2002/088.pdf) family of bilinear groups.
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://eprint.iacr.org/2002/088.pdf>`
   |
note: the lint level is defined here
  --> src/lib.rs:5:5
   |
5  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(non_autolinks)]` implied by `#[deny(warnings)]`

error: this URL is not a hyperlink
  --> src/groups/curves/short_weierstrass/mod.rs:17:20
   |
17 | /// the [\[MNT4]\](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf)
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf>`

error: this URL is not a hyperlink
  --> src/groups/curves/short_weierstrass/mod.rs:21:20
   |
21 | /// the [\[MNT6]\](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf)
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.20.8113&rep=rep1&type=pdf>`

error: aborting due to 3 previous errors

error: could not document `ark-r1cs-std`
```