### PR TITLE
Let `Radix2Domain::offset` to be `FpVar` instead of `F`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,18 @@
 
 ### Breaking changes
 
-- #60 Rename `AllocatedBit` to `AllocatedBool` for consistency with the `Boolean` variable.
-You can update downstream usage with `grep -rl 'AllocatedBit' . | xargs env LANG=C env LC_CTYPE=C sed -i '' 's/AllocatedBit/AllocatedBool/g'`.
+- [\#60](https://github.com/arkworks-rs/r1cs-std/pull/60) Rename `AllocatedBit` to `AllocatedBool` for consistency with the `Boolean` variable.
+  You can update downstream usage with `grep -rl 'AllocatedBit' . | xargs env LANG=C env LC_CTYPE=C sed -i '' 's/AllocatedBit/AllocatedBool/g'`.
+- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Rename `Radix2Domain` in `r1cs-std` to `Radix2DomainVar`.
 
 ### Features
 
 - [\#53](https://github.com/arkworks-rs/r1cs-std/pull/53) Add univariate evaluation domain and lagrange interpolation. 
 
 ### Improvements
-- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Add support for non-constant coset offset in `Radix2DomainVar`
+
+- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Add support for non-constant coset offset in `Radix2DomainVar`.
+
 ### Bug Fixes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Features
 
-- [\#53](https://github.com/arkworks-rs/r1cs-std/pull/53) Add univariate evaluation domain and lagrange interpolation. 
+- [\#53](https://github.com/arkworks-rs/r1cs-std/pull/53) Add univariate evaluation domain and Lagrange interpolation. 
 
 ### Improvements
 
@@ -20,14 +20,17 @@
 ## v0.2.0
 
 ### Breaking changes
+
 - [\#12](https://github.com/arkworks-rs/r1cs-std/pull/12) Make the output of the `ToBitsGadget` impl for `FpVar` fixed-size
 - [\#48](https://github.com/arkworks-rs/r1cs-std/pull/48) Add `Clone` trait bound to `CondSelectGadget`.
-- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Rename `Radix2Domain` to `Radix2DomainVar`
+
 ### Features
+
 - [\#21](https://github.com/arkworks-rs/r1cs-std/pull/21) Add `UInt128`
 - [\#50](https://github.com/arkworks-rs/r1cs-std/pull/50) Add `DensePolynomialVar`
 
 ### Improvements
+
 - [\#5](https://github.com/arkworks-rs/r1cs-std/pull/5) Speedup BLS-12 pairing
 - [\#13](https://github.com/arkworks-rs/r1cs-std/pull/13) Add `ToConstraintFieldGadget` to `ProjectiveVar`
 - [\#15](https://github.com/arkworks-rs/r1cs-std/pull/15), #16 Allow `cs` to be `None` when converting a Montgomery point into a Twisted Edwards point
@@ -41,6 +44,7 @@
 - [\#46](https://github.com/arkworks-rs/r1cs-std/pull/46) Add mux gadget as an auto-impl in `CondSelectGadget` to support random access of an array
 
 ### Bug fixes
+
 - [\#8](https://github.com/arkworks-rs/r1cs-std/pull/8) Fix bug in `three_bit_cond_neg_lookup` when using a constant lookup bit
 - [\#9](https://github.com/arkworks-rs/r1cs-std/pull/9) Fix bug in `short_weierstrass::ProjectiveVar::to_affine`
 - [\#29](https://github.com/arkworks-rs/r1cs-std/pull/29) Fix `to_non_unique_bytes` for `BLS12::G1Prepared`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ You can update downstream usage with `grep -rl 'AllocatedBit' . | xargs env LANG
 - [\#53](https://github.com/arkworks-rs/r1cs-std/pull/53) Add univariate evaluation domain and lagrange interpolation. 
 
 ### Improvements
-
+- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Add support for non-constant coset offset in `Radix2DomainVar`
 ### Bug Fixes
 
 
@@ -19,7 +19,7 @@ You can update downstream usage with `grep -rl 'AllocatedBit' . | xargs env LANG
 ### Breaking changes
 - [\#12](https://github.com/arkworks-rs/r1cs-std/pull/12) Make the output of the `ToBitsGadget` impl for `FpVar` fixed-size
 - [\#48](https://github.com/arkworks-rs/r1cs-std/pull/48) Add `Clone` trait bound to `CondSelectGadget`.
-
+- [\#65](https://github.com/arkworks-rs/r1cs-std/pull/65) Rename `Radix2Domain` to `Radix2DomainVar`
 ### Features
 - [\#21](https://github.com/arkworks-rs/r1cs-std/pull/21) Add `UInt128`
 - [\#50](https://github.com/arkworks-rs/r1cs-std/pull/50) Add `DensePolynomialVar`

--- a/src/poly/domain/mod.rs
+++ b/src/poly/domain/mod.rs
@@ -51,7 +51,7 @@ impl<F: PrimeField> Radix2DomainVar<F> {
         result
     }
 
-    /// Size of coset
+    /// Size of the domain
     pub fn size(&self) -> u64 {
         1 << self.dim
     }

--- a/src/poly/domain/mod.rs
+++ b/src/poly/domain/mod.rs
@@ -51,6 +51,11 @@ impl<F: PrimeField> Radix2DomainVar<F> {
         result
     }
 
+    /// Size of coset
+    pub fn size(&self) -> u64 {
+        1 << self.dim
+    }
+
     /// For domain `h<g>` with dimension `n`, `position` represented by `query_pos` in big endian form,
     /// returns `h*g^{position}<g^{n-query_pos.len()}>`
     pub fn query_position_to_coset(

--- a/src/poly/domain/mod.rs
+++ b/src/poly/domain/mod.rs
@@ -1,7 +1,7 @@
 use crate::boolean::Boolean;
+use crate::eq::EqGadget;
 use crate::fields::fp::FpVar;
 use crate::fields::FieldVar;
-use crate::R1CSVar;
 use ark_ff::PrimeField;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::vec::Vec;
@@ -24,13 +24,13 @@ pub struct Radix2DomainVar<F: PrimeField> {
     pub dim: u64,
 }
 
-impl<F: PrimeField> Radix2DomainVar<F> {
-    /// returns whether two domains are same without comparing if `offset`
-    /// represents same variable in circuit.
-    pub fn is_same_value(&self, other: &Self) -> bool {
-        (self.gen == other.gen)
-            && (self.offset.value().unwrap() == other.offset.value().unwrap())
-            && (self.dim == other.dim)
+impl<F: PrimeField> EqGadget<F> for Radix2DomainVar<F> {
+    fn is_eq(&self, other: &Self) -> Result<Boolean<F>, SynthesisError> {
+        if self.gen != other.gen || self.dim != other.dim {
+            Ok(Boolean::constant(false))
+        } else {
+            self.offset.is_eq(&other.offset)
+        }
     }
 }
 

--- a/src/poly/evaluations/univariate/mod.rs
+++ b/src/poly/evaluations/univariate/mod.rs
@@ -211,9 +211,11 @@ impl<'a, 'b, F: PrimeField> Add<&'a EvaluationsVar<F>> for &'b EvaluationsVar<F>
 }
 
 impl<'a, F: PrimeField> AddAssign<&'a EvaluationsVar<F>> for EvaluationsVar<F> {
+    /// Performs the `+=` operations, assuming `domain.offset` is equal.
     fn add_assign(&mut self, other: &'a EvaluationsVar<F>) {
+        // offset might be unknown at compile time, so we assume offset is equal
         assert!(
-            self.domain.is_same_value(&other.domain),
+            self.domain.gen == other.domain.gen && self.domain.dim == other.domain.dim,
             "domains are unequal"
         );
 
@@ -236,9 +238,11 @@ impl<'a, 'b, F: PrimeField> Sub<&'a EvaluationsVar<F>> for &'b EvaluationsVar<F>
 }
 
 impl<'a, F: PrimeField> SubAssign<&'a EvaluationsVar<F>> for EvaluationsVar<F> {
+    /// Performs the `-=` operations, assuming `domain.offset` is equal.
     fn sub_assign(&mut self, other: &'a EvaluationsVar<F>) {
+        // offset might be unknown at compile time, so we assume offset is equal
         assert!(
-            self.domain.is_same_value(&other.domain),
+            self.domain.gen == other.domain.gen && self.domain.dim == other.domain.dim,
             "domains are unequal"
         );
 
@@ -253,6 +257,7 @@ impl<'a, F: PrimeField> SubAssign<&'a EvaluationsVar<F>> for EvaluationsVar<F> {
 impl<'a, 'b, F: PrimeField> Mul<&'a EvaluationsVar<F>> for &'b EvaluationsVar<F> {
     type Output = EvaluationsVar<F>;
 
+    /// Performs the `*` operations, assuming `domain.offset` is equal.
     fn mul(self, rhs: &'a EvaluationsVar<F>) -> Self::Output {
         let mut result = self.clone();
         result *= rhs;
@@ -261,9 +266,11 @@ impl<'a, 'b, F: PrimeField> Mul<&'a EvaluationsVar<F>> for &'b EvaluationsVar<F>
 }
 
 impl<'a, F: PrimeField> MulAssign<&'a EvaluationsVar<F>> for EvaluationsVar<F> {
+    /// Performs the `*=` operations, assuming `domain.offset` is equal.
     fn mul_assign(&mut self, other: &'a EvaluationsVar<F>) {
+        // offset might be unknown at compile time, so we assume offset is equal
         assert!(
-            self.domain.is_same_value(&other.domain),
+            self.domain.gen == other.domain.gen && self.domain.dim == other.domain.dim,
             "domains are unequal"
         );
 
@@ -286,9 +293,11 @@ impl<'a, 'b, F: PrimeField> Div<&'a EvaluationsVar<F>> for &'b EvaluationsVar<F>
 }
 
 impl<'a, F: PrimeField> DivAssign<&'a EvaluationsVar<F>> for EvaluationsVar<F> {
+    /// Performs the `/=` operations, assuming `domain.offset` is equal.
     fn div_assign(&mut self, other: &'a EvaluationsVar<F>) {
+        // offset might be unknown at compile time, so we assume offset is equal
         assert!(
-            self.domain.is_same_value(&other.domain),
+            self.domain.gen == other.domain.gen && self.domain.dim == other.domain.dim,
             "domains are unequal"
         );
         let cs = self.evals[0].cs();

--- a/src/poly/evaluations/univariate/mod.rs
+++ b/src/poly/evaluations/univariate/mod.rs
@@ -19,6 +19,11 @@ pub struct EvaluationsVar<F: PrimeField> {
     /// Optional Lagrange Interpolator. Useful for lagrange interpolation.
     pub lagrange_interpolator: Option<LagrangeInterpolator<F>>,
     domain: Radix2DomainVar<F>,
+    /// Contains all domain elements of `domain.base_domain`.
+    ///
+    /// This is Cache for lagrange interpolation when offset is non-constant. Will be `None` if offset is constant
+    /// or `interpolate` is set to `false`.
+    subgroup_points: Option<Vec<F>>,
 }
 
 impl<F: PrimeField> EvaluationsVar<F> {
@@ -40,24 +45,35 @@ impl<F: PrimeField> EvaluationsVar<F> {
             evals: evaluations,
             lagrange_interpolator: None,
             domain,
+            subgroup_points: None,
         };
         if interpolate {
-            ev.generate_lagrange_interpolator();
+            ev.generate_interpolate_cache();
         }
         ev
     }
 
-    /// Generate lagrange interpolator in native code and mark it ready to interpolate.
-    /// This method is valid only if `self.domain.offset` is a constant.
-    pub fn generate_lagrange_interpolator(&mut self) {
-        let poly_evaluations_val: Vec<_> = self.evals.iter().map(|v| v.value().unwrap()).collect();
-        let domain = &self.domain;
-        let lagrange_interpolator = if let FpVar::Constant(x) = domain.offset {
-            LagrangeInterpolator::new(x, domain.gen, domain.dim, poly_evaluations_val)
+    /// Precompute necessary calculation for lagrange interpolation and mark it ready to interpolate
+    pub fn generate_interpolate_cache(&mut self) {
+        if self.domain.offset.is_constant() {
+            let poly_evaluations_val: Vec<_> =
+                self.evals.iter().map(|v| v.value().unwrap()).collect();
+            let domain = &self.domain;
+            let lagrange_interpolator = if let FpVar::Constant(x) = domain.offset {
+                LagrangeInterpolator::new(x, domain.gen, domain.dim, poly_evaluations_val)
+            } else {
+                panic!("Domain offset needs to be constant.")
+            };
+            self.lagrange_interpolator = Some(lagrange_interpolator)
         } else {
-            panic!("Domain offset needs to be constant.")
-        };
-        self.lagrange_interpolator = Some(lagrange_interpolator)
+            // calculate all elements of base subgroup so that in later part we don't need to calculate the exponents again
+            let mut subgroup_points = Vec::with_capacity(self.domain.size() as usize);
+            subgroup_points.push(F::one());
+            for i in 1..self.domain.size() as usize {
+                subgroup_points.push(subgroup_points[i - 1] * self.domain.gen)
+            }
+            self.subgroup_points = Some(subgroup_points)
+        }
     }
 
     /// Compute lagrange coefficients for each evaluation, given `interpolation_point`.
@@ -73,7 +89,7 @@ impl<F: PrimeField> EvaluationsVar<F> {
             .lagrange_interpolator
             .as_ref()
             .expect("lagrange interpolator has not been initialized. \
-            Call `self.generate_lagrange_interpolator` first or set `interpolate` to true in constructor. ");
+            Call `self.generate_interpolate_cache` first or set `interpolate` to true in constructor. ");
         let lagrange_coeffs =
             lagrange_interpolator.compute_lagrange_coefficients(t.value().unwrap());
         let mut lagrange_coeffs_fg = Vec::new();
@@ -114,22 +130,73 @@ impl<F: PrimeField> EvaluationsVar<F> {
     ) -> Result<FpVar<F>, SynthesisError> {
         // specialize: if domain offset is constant, we can optimize to have fewer constraints
         if self.domain.offset.is_constant() {
-            let lagrange_interpolator = self
-                .lagrange_interpolator
-                .as_ref()
-                .expect("lagrange interpolator has not been initialized. ");
-            let lagrange_coeffs = self.compute_lagrange_coefficients(interpolation_point)?;
-            let mut interpolation: FpVar<F> = FpVar::zero();
-            for i in 0..lagrange_interpolator.domain_order {
-                let intermediate = &lagrange_coeffs[i] * &self.evals[i];
-                interpolation += &intermediate
-            }
-
-            Ok(interpolation)
+            self.lagrange_interpolate_with_constant_offset(interpolation_point)
         } else {
             // if domain offset is not constant, then we use standard lagrange interpolation code
-            todo!()
+            self.lagrange_interpolate_with_non_constant_offset(interpolation_point)
         }
+    }
+
+    fn lagrange_interpolate_with_constant_offset(
+        &self,
+        interpolation_point: &FpVar<F>,
+    ) -> Result<FpVar<F>, SynthesisError> {
+        let lagrange_interpolator = self
+            .lagrange_interpolator
+            .as_ref()
+            .expect("lagrange interpolator has not been initialized. ");
+        let lagrange_coeffs = self.compute_lagrange_coefficients(interpolation_point)?;
+        let mut interpolation: FpVar<F> = FpVar::zero();
+        for i in 0..lagrange_interpolator.domain_order {
+            let intermediate = &lagrange_coeffs[i] * &self.evals[i];
+            interpolation += &intermediate
+        }
+
+        Ok(interpolation)
+    }
+
+    /// Generate interpolation constraints. We assume at compile time we know the base coset (i.e. `gen`) but not know `offset`.
+    fn lagrange_interpolate_with_non_constant_offset(
+        &self,
+        interpolation_point: &FpVar<F>,
+    ) -> Result<FpVar<F>, SynthesisError> {
+        // first, make sure `subgroup_points` is made
+        let subgroup_points = self.subgroup_points.as_ref()
+            .expect("lagrange interpolator has not been initialized. \
+            Call `self.generate_interpolate_cache` first or set `interpolate` to true in constructor. ");
+        // Let denote interpolation_point as alpha.
+        // Lagrange polynomial for coset element `a` is
+        // \frac{1}{size * offset ^ size} * \frac{alpha^size - offset^size}{alpha * a^{-1} - 1}
+        // Notice that a = (offset * a') where a' is the corresponding element of base coset
+
+        // let `lhs` become \frac{alpha^size - offset^size}{size * offset ^ size}. This part is shared by all lagrange polynomials
+        let coset_offset_to_size = self.domain.offset.pow_by_constant(&[self.domain.size()])?; // offset^size
+        let alpha_to_s = interpolation_point.pow_by_constant(&[self.domain.size()])?;
+        let lhs_numerator = &alpha_to_s - &coset_offset_to_size;
+        let lhs_denominator = &coset_offset_to_size * FpVar::constant(F::from(self.domain.size()));
+
+        let lhs = lhs_numerator.mul_by_inverse(&lhs_denominator)?;
+
+        // `rhs` for coset element `a` is \frac{1}{alpha * a^{-1} - 1} = \frac{1}{alpha * offset^{-1} * a'^{-1} - 1}
+        let alpha_coset_offset_inv = interpolation_point.mul_by_inverse(&self.domain.offset)?;
+
+        // `res` stores the sum of all lagrange polynomials evaluated at alpha
+        let mut res = FpVar::<F>::zero();
+
+        let domain_size = self.domain.size() as usize;
+        for i in 0..domain_size {
+            // a'^{-1} where a is the base coset element
+            let subgroup_point_inv = subgroup_points[(domain_size - i) % domain_size];
+            debug_assert_eq!(subgroup_points[i] * subgroup_point_inv, F::one());
+            // alpha * offset^{-1} * a'^{-1} - 1
+            let lag_donom = &alpha_coset_offset_inv * subgroup_point_inv - F::one();
+            let lag_coeff = lhs.mul_by_inverse(&lag_donom)?;
+
+            let lag_interpoland = &self.evals[i] * lag_coeff;
+            res += lag_interpoland
+        }
+
+        Ok(res)
     }
 }
 
@@ -271,7 +338,7 @@ mod tests {
         assert_eq!(gen.pow(&[1 << 4]), Fr::one());
         let domain = Radix2DomainVar {
             gen,
-            offset: FpVar::constant(Fr::multiplicative_generator()),
+            offset: FpVar::constant(Fr::rand(&mut rng)),
             dim: 4, // 2^4 = 16
         };
         let mut coset_point = domain.offset.value().unwrap();
@@ -301,6 +368,49 @@ mod tests {
 
         assert_eq!(actual, expected);
         assert!(cs.is_satisfied().unwrap());
+        println!("number of constraints: {}", cs.num_constraints())
+    }
+
+    #[test]
+    fn test_interpolate_non_constant_offset() {
+        let mut rng = test_rng();
+        let poly = DensePolynomial::rand(15, &mut rng);
+        let gen = Fr::get_root_of_unity(1 << 4).unwrap();
+        assert_eq!(gen.pow(&[1 << 4]), Fr::one());
+        let cs = ConstraintSystem::new_ref();
+        let domain = Radix2DomainVar {
+            gen,
+            offset: FpVar::new_witness(ns!(cs, "offset"), || Ok(Fr::rand(&mut rng))).unwrap(),
+            dim: 4, // 2^4 = 16
+        };
+        let mut coset_point = domain.offset.value().unwrap();
+        let mut oracle_evals = Vec::new();
+        for _ in 0..(1 << 4) {
+            oracle_evals.push(poly.evaluate(&coset_point));
+            coset_point *= gen;
+        }
+
+        let evaluations_fp: Vec<_> = oracle_evals
+            .iter()
+            .map(|x| FpVar::new_input(ns!(cs, "evaluations"), || Ok(x)).unwrap())
+            .collect();
+        let evaluations_var = EvaluationsVar::from_vec_and_domain(evaluations_fp, domain, true);
+
+        let interpolate_point = Fr::rand(&mut rng);
+        let interpolate_point_fp =
+            FpVar::new_input(ns!(cs, "interpolate point"), || Ok(interpolate_point)).unwrap();
+
+        let expected = poly.evaluate(&interpolate_point);
+
+        let actual = evaluations_var
+            .interpolate_and_evaluate(&interpolate_point_fp)
+            .unwrap()
+            .value()
+            .unwrap();
+
+        assert_eq!(actual, expected);
+        assert!(cs.is_satisfied().unwrap());
+        println!("number of constraints: {}", cs.num_constraints())
     }
 
     #[test]

--- a/src/poly/evaluations/univariate/mod.rs
+++ b/src/poly/evaluations/univariate/mod.rs
@@ -48,13 +48,13 @@ impl<F: PrimeField> EvaluationsVar<F> {
             subgroup_points: None,
         };
         if interpolate {
-            ev.generate_interpolate_cache();
+            ev.generate_interpolation_cache();
         }
         ev
     }
 
     /// Precompute necessary calculation for lagrange interpolation and mark it ready to interpolate
-    pub fn generate_interpolate_cache(&mut self) {
+    pub fn generate_interpolation_cache(&mut self) {
         if self.domain.offset.is_constant() {
             let poly_evaluations_val: Vec<_> =
                 self.evals.iter().map(|v| v.value().unwrap()).collect();

--- a/src/poly/evaluations/univariate/mod.rs
+++ b/src/poly/evaluations/univariate/mod.rs
@@ -89,7 +89,7 @@ impl<F: PrimeField> EvaluationsVar<F> {
             .lagrange_interpolator
             .as_ref()
             .expect("lagrange interpolator has not been initialized. \
-            Call `self.generate_interpolate_cache` first or set `interpolate` to true in constructor. ");
+            Call `self.generate_interpolation_cache` first or set `interpolate` to true in constructor. ");
         let lagrange_coeffs =
             lagrange_interpolator.compute_lagrange_coefficients(t.value().unwrap());
         let mut lagrange_coeffs_fg = Vec::new();
@@ -163,7 +163,7 @@ impl<F: PrimeField> EvaluationsVar<F> {
         // first, make sure `subgroup_points` is made
         let subgroup_points = self.subgroup_points.as_ref()
             .expect("lagrange interpolator has not been initialized. \
-            Call `self.generate_interpolate_cache` first or set `interpolate` to true in constructor. ");
+            Call `self.generate_interpolation_cache` first or set `interpolate` to true in constructor. ");
         // Let denote interpolation_point as alpha.
         // Lagrange polynomial for coset element `a` is
         // \frac{1}{size * offset ^ size} * \frac{alpha^size - offset^size}{alpha * a^{-1} - 1}

--- a/src/poly/evaluations/univariate/mod.rs
+++ b/src/poly/evaluations/univariate/mod.rs
@@ -21,7 +21,7 @@ pub struct EvaluationsVar<F: PrimeField> {
     domain: Radix2DomainVar<F>,
     /// Contains all domain elements of `domain.base_domain`.
     ///
-    /// This is Cache for lagrange interpolation when offset is non-constant. Will be `None` if offset is constant
+    /// This is a cache for lagrange interpolation when offset is non-constant. Will be `None` if offset is constant
     /// or `interpolate` is set to `false`.
     subgroup_points: Option<Vec<F>>,
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Current `Radix2Domain` does not support non-constant offset. This PR adds that functionality. 

**Highlighted Changes:** 
- `Radix2Domain` will be renamed to `Radix2DomainVar`
- `Radix2DomainVar` will offset that is `FpVar` instead of `F`
- `Radix2DomainVar::interpolate_and_evaluate` will specialize according to whether `self.offset` is constant or not. 


closes: #64 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
