### PR TITLE
Implement the `Sum` trait for `FpVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#71](https://github.com/arkworks-rs/r1cs-std/pull/71) Implement the `Sum` trait for `FpVar`.
+
 ### Improvements
 
 ### Bug Fixes

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1,5 +1,7 @@
 use ark_ff::{BigInteger, FpParameters, PrimeField};
-use ark_relations::r1cs::{ConstraintSystemRef, LinearCombination, Namespace, SynthesisError, Variable};
+use ark_relations::r1cs::{
+    ConstraintSystemRef, LinearCombination, Namespace, SynthesisError, Variable,
+};
 
 use core::borrow::Borrow;
 
@@ -126,11 +128,11 @@ impl<F: PrimeField> AllocatedFp<F> {
     /// Add many allocated Fp elements together.
     ///
     /// This does not create any constraints and only create one linear combination.
-    pub fn addmany<'a, I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    pub fn addmany<'a, I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         let mut cs = ConstraintSystemRef::None;
         let mut has_value = true;
         let mut value = F::zero();
-        let mut new_lc= lc!();
+        let mut new_lc = lc!();
 
         for variable in iter {
             if !variable.cs.is_none() {
@@ -144,9 +146,7 @@ impl<F: PrimeField> AllocatedFp<F> {
             new_lc = new_lc + variable.variable;
         }
 
-        let variable = cs
-            .new_lc(new_lc)
-            .unwrap();
+        let variable = cs.new_lc(new_lc).unwrap();
 
         if has_value {
             AllocatedFp::new(Some(value), variable, cs.clone())
@@ -1035,18 +1035,15 @@ impl<F: PrimeField> AllocVar<F, F> for FpVar<F> {
 }
 
 impl<'a, F: PrimeField> Sum<&'a FpVar<F>> for FpVar<F> {
-    fn sum<I: Iterator<Item=&'a FpVar<F>>>(iter: I) -> FpVar<F> {
+    fn sum<I: Iterator<Item = &'a FpVar<F>>>(iter: I) -> FpVar<F> {
         let mut sum_constants = F::zero();
-        let sum_variables = FpVar::Var(AllocatedFp::<F>::addmany(iter.filter_map(|x|
-            {
-                match x {
-                    FpVar::Constant(c) => {
-                        sum_constants += c;
-                        None
-                    }
-                    FpVar::Var(v) => Some(v)
-                }
-            })));
+        let sum_variables = FpVar::Var(AllocatedFp::<F>::addmany(iter.filter_map(|x| match x {
+            FpVar::Constant(c) => {
+                sum_constants += c;
+                None
+            }
+            FpVar::Var(v) => Some(v),
+        })));
 
         let sum = sum_variables + sum_constants;
         sum
@@ -1055,13 +1052,13 @@ impl<'a, F: PrimeField> Sum<&'a FpVar<F>> for FpVar<F> {
 
 #[cfg(test)]
 mod test {
-    use ark_test_curves::bls12_381::Fr;
-    use ark_relations::r1cs::ConstraintSystem;
-    use crate::fields::fp::FpVar;
     use crate::alloc::{AllocVar, AllocationMode};
-    use ark_std::{Zero, UniformRand};
-    use crate::R1CSVar;
     use crate::eq::EqGadget;
+    use crate::fields::fp::FpVar;
+    use crate::R1CSVar;
+    use ark_relations::r1cs::ConstraintSystem;
+    use ark_std::{UniformRand, Zero};
+    use ark_test_curves::bls12_381::Fr;
 
     #[test]
     fn test_sum_fpvar() {
@@ -1074,12 +1071,16 @@ mod test {
         for _ in 0..10 {
             let a = Fr::rand(&mut rng);
             sum_expected += &a;
-            v.push(FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Constant).unwrap());
+            v.push(
+                FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Constant).unwrap(),
+            );
         }
         for _ in 0..10 {
             let a = Fr::rand(&mut rng);
             sum_expected += &a;
-            v.push(FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Witness).unwrap());
+            v.push(
+                FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Witness).unwrap(),
+            );
         }
 
         let sum: FpVar<Fr> = v.iter().sum();

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -127,7 +127,7 @@ impl<F: PrimeField> AllocatedFp<F> {
 
     /// Add many allocated Fp elements together.
     ///
-    /// This does not create any constraints and only create one linear combination.
+    /// This does not create any constraints and only creates one linear combination.
     pub fn addmany<'a, I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         let mut cs = ConstraintSystemRef::None;
         let mut has_value = true;

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1,7 +1,5 @@
 use ark_ff::{BigInteger, FpParameters, PrimeField};
-use ark_relations::r1cs::{
-    ConstraintSystemRef, LinearCombination, Namespace, SynthesisError, Variable,
-};
+use ark_relations::r1cs::{ConstraintSystemRef, LinearCombination, Namespace, SynthesisError, Variable};
 
 use core::borrow::Borrow;
 
@@ -10,6 +8,7 @@ use crate::{
     prelude::*,
     Assignment, ToConstraintFieldGadget, Vec,
 };
+use ark_std::iter::Sum;
 
 mod cmp;
 
@@ -122,6 +121,38 @@ impl<F: PrimeField> AllocatedFp<F> {
             .new_lc(lc!() + self.variable + other.variable)
             .unwrap();
         AllocatedFp::new(value, variable, self.cs.clone())
+    }
+
+    /// Add many allocated Fp elements together.
+    ///
+    /// This does not create any constraints and only create one linear combination.
+    pub fn addmany<'a, I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        let mut cs = ConstraintSystemRef::None;
+        let mut has_value = true;
+        let mut value = F::zero();
+        let mut new_lc= lc!();
+
+        for variable in iter {
+            if !variable.cs.is_none() {
+                cs = cs.or(variable.cs.clone());
+            }
+            if variable.value.is_none() {
+                has_value = false;
+            } else {
+                value += variable.value.unwrap();
+            }
+            new_lc = new_lc + variable.variable;
+        }
+
+        let variable = cs
+            .new_lc(new_lc)
+            .unwrap();
+
+        if has_value {
+            AllocatedFp::new(Some(value), variable, cs.clone())
+        } else {
+            AllocatedFp::new(None, variable, cs.clone())
+        }
     }
 
     /// Outputs `self - other`.
@@ -1000,5 +1031,62 @@ impl<F: PrimeField> AllocVar<F, F> for FpVar<F> {
         } else {
             AllocatedFp::new_variable(cs, f, mode).map(Self::Var)
         }
+    }
+}
+
+impl<'a, F: PrimeField> Sum<&'a FpVar<F>> for FpVar<F> {
+    fn sum<I: Iterator<Item=&'a FpVar<F>>>(iter: I) -> FpVar<F> {
+        let mut sum_constants = F::zero();
+        let sum_variables = FpVar::Var(AllocatedFp::<F>::addmany(iter.filter_map(|x|
+            {
+                match x {
+                    FpVar::Constant(c) => {
+                        sum_constants += c;
+                        None
+                    }
+                    FpVar::Var(v) => Some(v)
+                }
+            })));
+
+        let sum = sum_variables + sum_constants;
+        sum
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_test_curves::bls12_381::Fr;
+    use ark_relations::r1cs::ConstraintSystem;
+    use crate::fields::fp::FpVar;
+    use crate::alloc::{AllocVar, AllocationMode};
+    use ark_std::{Zero, UniformRand};
+    use crate::R1CSVar;
+    use crate::eq::EqGadget;
+
+    #[test]
+    fn test_sum_fpvar() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::new_ref();
+
+        let mut sum_expected = Fr::zero();
+
+        let mut v = Vec::new();
+        for _ in 0..10 {
+            let a = Fr::rand(&mut rng);
+            sum_expected += &a;
+            v.push(FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Constant).unwrap());
+        }
+        for _ in 0..10 {
+            let a = Fr::rand(&mut rng);
+            sum_expected += &a;
+            v.push(FpVar::<Fr>::new_variable(cs.clone(), || Ok(a), AllocationMode::Witness).unwrap());
+        }
+
+        let sum: FpVar<Fr> = v.iter().sum();
+
+        sum.enforce_equal(&FpVar::Constant(sum_expected)).unwrap();
+
+        assert!(cs.is_satisfied().unwrap());
+        assert_eq!(sum.value().unwrap(), sum_expected);
     }
 }


### PR DESCRIPTION
## Description

This PR is related to #68.

Basically, in some computations, a number of numbers will be added together. Although our writing system does not create many constraints for it, it creates many short linear combinations, which may slow down `inline_all_lcs`.

This PR closes #68.

A test is included.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
