### PR TITLE
Bug Fix in `domain` and API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- [\#86](https://github.com/arkworks-rs/r1cs-std/pull/86) Make result of `query_position_to_coset` consistent with `ark-ldt`.
 - [\#77](https://github.com/arkworks-rs/r1cs-std/pull/77) Fix BLS12 `G2PreparedGadget`'s `AllocVar` when G2 uses a divisive twist.
 
 ## v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- [\#86](https://github.com/arkworks-rs/r1cs-std/pull/86) Change the API for domains for coset.
+
 ### Features
 
 - [\#79](https://github.com/arkworks-rs/r1cs-std/pull/79) Move `NonNativeFieldVar` from `ark-nonnative` to `ark-r1cs-std`.

--- a/src/poly/domain/mod.rs
+++ b/src/poly/domain/mod.rs
@@ -60,7 +60,7 @@ impl<F: PrimeField> Radix2DomainVar<F> {
     pub fn elements(&self) -> Vec<FpVar<F>> {
         let mut result = Vec::new();
         result.push(self.offset.clone());
-        for _ in 0..(1 << self.dim) {
+        for _ in 1..(1 << self.dim) {
             let new_element = result.last().unwrap() * self.gen;
             result.push(new_element);
         }

--- a/src/poly/domain/mod.rs
+++ b/src/poly/domain/mod.rs
@@ -20,7 +20,7 @@ pub struct Radix2DomainVar<F: PrimeField> {
     pub gen: F,
     /// index of the quotient group (i.e. the `offset`)
     offset: FpVar<F>,
-    /// dimension of evaluation domain
+    /// dimension of evaluation domain, which is log2(size of coset)
     pub dim: u64,
 }
 impl<F: PrimeField> Radix2DomainVar<F> {
@@ -56,13 +56,13 @@ impl<F: PrimeField> Radix2DomainVar<F> {
         1 << self.dim
     }
 
-    /// Returns g, g^2, ..., g^{dim}
-    fn powers_of_gen(&self, dim: usize) -> Vec<F> {
+    /// Returns offset, offset*g, offset*g^2, ..., offset*g^{coset_size}
+    pub fn elements(&self) -> Vec<FpVar<F>> {
         let mut result = Vec::new();
-        let mut cur = self.gen;
-        for _ in 0..dim {
-            result.push(cur);
-            cur = cur * cur;
+        result.push(self.offset.clone());
+        for _ in 0..(1 << self.dim) {
+            let new_element = result.last().unwrap() * self.gen;
+            result.push(new_element);
         }
         result
     }
@@ -73,37 +73,122 @@ impl<F: PrimeField> Radix2DomainVar<F> {
     }
 
     /// For domain `h<g>` with dimension `n`, `position` represented by `query_pos` in big endian form,
-    /// returns `h*g^{position}<g^{n-query_pos.len()}>`
-    pub fn query_position_to_coset(
+    /// returns all points of `h*g^{position}<g^{2^{n-coset_dim}}>`. The result is the query coset at index `query_pos`
+    /// for the FRI protocol.
+    ///
+    /// # Panics
+    /// This function panics when `query_pos.len() != coset_dim` or `query_pos.len() != self.dim`.  
+    pub fn query_position_to_coset_elements(
         &self,
         query_pos: &[Boolean<F>],
         coset_dim: u64,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let mut coset_index = query_pos;
-        assert!(
-            query_pos.len() == self.dim as usize
-                || query_pos.len() == (self.dim - coset_dim) as usize
-        );
-        if query_pos.len() == self.dim as usize {
-            coset_index = &coset_index[0..(coset_index.len() - coset_dim as usize)];
-        }
+        let coset_index = truncate_to_coset_index(query_pos, self.dim, coset_dim);
         let mut coset = Vec::new();
-        let powers_of_g = &self.powers_of_gen(self.dim as usize)[(coset_dim as usize)..];
 
-        let mut first_point_in_coset: FpVar<F> = FpVar::zero();
-        for i in 0..coset_index.len() {
-            let term = coset_index[i].select(&FpVar::constant(powers_of_g[i]), &FpVar::zero())?;
-            first_point_in_coset += &term;
-        }
+        let offset_var: FpVar<F> =
+            FpVar::Constant(self.gen).pow_le(&coset_index).unwrap() * &self.offset;
 
-        first_point_in_coset *= &self.offset;
-
-        coset.push(first_point_in_coset);
+        coset.push(offset_var);
         for i in 1..(1 << (coset_dim as usize)) {
-            let new_elem = &coset[i - 1] * &FpVar::Constant(self.gen);
+            let new_elem =
+                &coset[i - 1] * &FpVar::Constant(self.gen.pow(&[1 << (self.dim - coset_dim)]));
             coset.push(new_elem);
         }
 
         Ok(coset)
+    }
+
+    /// For domain `h<g>` with dimension `n`, `position` represented by `query_pos` in big endian form,
+    /// returns all points of `h*g^{position}<g^{n-query_pos.len()}>`
+    ///
+    /// If you just need to get coset elements, use `query_position_to_coset_elements` instead.
+    ///
+    /// # Panics
+    /// This function panics when `query_pos.len() != coset_dim` or `query_pos.len() != self.dim`.  
+    pub fn query_position_to_coset(
+        &self,
+        query_pos: &[Boolean<F>],
+        coset_dim: u64,
+    ) -> Result<Self, SynthesisError> {
+        let coset_index = truncate_to_coset_index(query_pos, self.dim, coset_dim);
+        let offset_var = &self.offset * FpVar::Constant(self.gen).pow_le(&coset_index)?;
+        Ok(Self {
+            gen: self.gen.pow(&[1 << (self.dim - coset_dim)]), // distance between coset
+            offset: offset_var,
+            dim: coset_dim,
+        })
+    }
+}
+
+fn truncate_to_coset_index<F: PrimeField>(
+    query_pos: &[Boolean<F>],
+    codeword_dim: u64,
+    coset_dim: u64,
+) -> Vec<Boolean<F>> {
+    assert!(query_pos.len() == codeword_dim as usize || query_pos.len() == coset_dim as usize);
+    if query_pos.len() == codeword_dim as usize {
+        query_pos[0..(query_pos.len() - coset_dim as usize)].to_vec()
+    } else {
+        query_pos.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::PrimeField;
+    use ark_relations::r1cs::ConstraintSystem;
+    use ark_std::{rand::Rng, test_rng};
+
+    use crate::{
+        alloc::AllocVar, boolean::Boolean, fields::fp::FpVar, poly::domain::Radix2DomainVar,
+        R1CSVar,
+    };
+
+    fn test_query_coset_template<F: PrimeField>() {
+        const COSET_DIM: u64 = 7;
+        const COSET_SIZE: usize = 1 << COSET_DIM;
+        const LOCALIZATION: u64 = 3;
+        let cs = ConstraintSystem::new_ref();
+        let mut rng = test_rng();
+        let gen = F::get_root_of_unity(COSET_SIZE).unwrap();
+        let offset = F::rand(&mut rng);
+        let offset_var = FpVar::new_witness(cs.clone(), || Ok(offset)).unwrap();
+        let domain = Radix2DomainVar::new(gen, COSET_DIM, offset_var).unwrap();
+
+        let query_index = (0..COSET_DIM)
+            .map(|_| Boolean::<F>::new_witness(cs.clone(), || Ok(rng.gen::<bool>())).unwrap())
+            .collect::<Vec<_>>();
+
+        let queried_coset = domain
+            .query_position_to_coset(&query_index, LOCALIZATION)
+            .unwrap();
+
+        let queried_coset_elements_left = domain
+            .query_position_to_coset_elements(&query_index, LOCALIZATION)
+            .unwrap();
+
+        let queried_coset_elements_right = queried_coset.elements();
+
+        assert_eq!(
+            queried_coset_elements_left.len(),
+            queried_coset_elements_right.len()
+        );
+        queried_coset_elements_left
+            .into_iter()
+            .zip(queried_coset_elements_right.into_iter())
+            .for_each(|(left, right)| {
+                assert_eq!(left.value().unwrap(), right.value().unwrap());
+            });
+    }
+
+    #[test]
+    fn test_on_bls12_381() {
+        test_query_coset_template::<ark_bls12_381::Fr>();
+    }
+
+    #[test]
+    fn test_on_bls12_377() {
+        test_query_coset_template::<ark_bls12_377::Fr>();
     }
 }


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently, `domain.query_position_to_coset` is not consistent native code in `ark-ldt`. This commit does the following changes:
* change `query_position_to_coset` to `query_position_to_coset_elements`, and make the return result consistent with native code
* add function `query_position_to_coset` to just return generator and offset instead of coset elements. 

closes: #85 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
