### PR TITLE
Let `cargo build` work again for the new arkworks-rs algebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,6 @@ include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 
-[profile.release]
-panic = 'abort'
-
-[profile.dev]
-panic = 'abort'
-
 [dependencies]
 ark-ff = { version = "^0.3.0", default-features = false }
 ark-ec = { version = "^0.3.0", default-features = false }
@@ -51,6 +45,31 @@ parallel = [ "std", "ark-ff/parallel", "ark-std/parallel"]
 name = "nonnative-bench"
 path = "benches/bench.rs"
 harness = false
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+incremental = true
+panic = 'abort'
+
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = "thin"
+incremental = true
+debug-assertions = false
+
+[profile.dev]
+opt-level = 0
+panic = 'abort'
+
+[profile.test]
+opt-level = 3
+lto = "thin"
+incremental = true
+debug-assertions = true
+debug = true
 
 # To be removed in the new release.
 [patch.crates-io]

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 };
 use ark_ff::{BigInteger, BitIteratorBE, Field, One, PrimeField, Zero};
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-use core::{borrow::Borrow, marker::PhantomData};
+use ark_std::{borrow::Borrow, marker::PhantomData, ops::Mul};
 use non_zero_affine::NonZeroAffineVar;
 
 use crate::{fields::fp::FpVar, prelude::*, ToConstraintFieldGadget, Vec};

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -12,7 +12,7 @@ use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 use crate::{prelude::*, ToConstraintFieldGadget, Vec};
 
 use crate::fields::fp::FpVar;
-use core::{borrow::Borrow, marker::PhantomData};
+use ark_std::{borrow::Borrow, marker::PhantomData, ops::Mul};
 
 /// An implementation of arithmetic for Montgomery curves that relies on
 /// incomplete addition formulae for the affine model, as outlined in the


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

I am trying to get the `r1cs-std` into running again. It appears that a small change is sufficient to make `cargo build` work. To make `cargo test` work, we should first to finish this PR in the `curves` repo: https://github.com/arkworks-rs/curves/pull/109

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
