### PR TITLE
Fix `is_zero` for twisted Edwards curves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
             echo "ark-ec = { git = 'https://github.com/arkworks-rs/algebra' }"
             echo "ark-ff = { git = 'https://github.com/arkworks-rs/algebra' }"
             echo "ark-poly = { git = 'https://github.com/arkworks-rs/algebra' }"
+            echo "ark-relations = { git = 'https://github.com/arkworks-rs/snark' }"
             echo "ark-serialize = { git = 'https://github.com/arkworks-rs/algebra' }"
             echo "ark-algebra-bench-templates = { git = 'https://github.com/arkworks-rs/algebra' }"
             echo "ark-algebra-test-templates = { git = 'https://github.com/arkworks-rs/algebra' }"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+- [\#101](https://github.com/arkworks-rs/r1cs-std/pull/101) Fix `is_zero` for twisted Edwards curves.
 - [\#86](https://github.com/arkworks-rs/r1cs-std/pull/86) Make result of `query_position_to_coset` consistent with `ark-ldt`.
 - [\#77](https://github.com/arkworks-rs/r1cs-std/pull/77) Fix BLS12 `G2PreparedGadget`'s `AllocVar` when G2 uses a divisive twist.
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -423,7 +423,7 @@ where
     }
 
     fn is_zero(&self) -> Result<Boolean<<P::BaseField as Field>::BasePrimeField>, SynthesisError> {
-        self.x.is_zero()?.and(&self.x.is_one()?)
+        self.x.is_zero()?.and(&self.y.is_one()?)
     }
 
     #[tracing::instrument(target = "r1cs", skip(cs, f))]


### PR DESCRIPTION
## Description

This appears to be a bug of two years. However, it also does not seem to affect any code.

The TE `is_zero` test is never true even if it is a zero.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code