### PR TITLE
Fix dangling batch normalization for twisted Edwards curves

### DIFF
--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -540,9 +540,9 @@ where
         let zero: TEAffine<P> = TEProjective::zero().into_affine();
         for (bits, multiples) in bits.chunks(2).zip(multiples.chunks(2)) {
             if bits.len() == 2 {
-                let mut table = [multiples[0], multiples[1], multiples[0] + multiples[1]];
+                let table_projective = [multiples[0], multiples[1], multiples[0] + multiples[1]];
 
-                table = TEProjective::normalize_batch(&table);
+                let table = TEProjective::normalize_batch(&table_projective);
                 let x_s = [zero.x, table[0].x, table[1].x, table[2].x];
                 let y_s = [zero.y, table[0].y, table[1].y, table[2].y];
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -542,7 +542,7 @@ where
             if bits.len() == 2 {
                 let mut table = [multiples[0], multiples[1], multiples[0] + multiples[1]];
 
-                TEProjective::normalize_batch(&mut table);
+                table = TEProjective::normalize_batch(table);
                 let x_s = [zero.x, table[0].x, table[1].x, table[2].x];
                 let y_s = [zero.y, table[0].y, table[1].y, table[2].y];
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -542,7 +542,7 @@ where
             if bits.len() == 2 {
                 let mut table = [multiples[0], multiples[1], multiples[0] + multiples[1]];
 
-                table = TEProjective::normalize_batch(table);
+                table = TEProjective::normalize_batch(&table);
                 let x_s = [zero.x, table[0].x, table[1].x, table[2].x];
                 let y_s = [zero.y, table[0].y, table[1].y, table[2].y];
 


### PR DESCRIPTION
## Description

It is discovered that Pedersen commitments are failing. After some debugging, we confirm that it is because `normalize_batch`, different from `batch_normalize`, returns the results instead of applying the mutation directly.

This PR fixes so.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A: 
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
