### PR TITLE
Montgomery cannot use TE affine as intermediate representations

### DIFF
--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -98,6 +98,7 @@ mod montgomery_affine_impl {
                 println!("{}", v);
                 GroupAffine::new(u, v)
             };
+            println!("-----");
 
             Ok((montgomery_point.x, montgomery_point.y))
         }

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -91,9 +91,9 @@ mod montgomery_affine_impl {
                 let u =
                     (P::BaseField::one() + &p.y) * &(P::BaseField::one() - &p.y).inverse().unwrap();
                 let v = u * &p.x.inverse().unwrap();
-
                 GroupAffine::new(u, v)
             };
+
             Ok((montgomery_point.x, montgomery_point.y))
         }
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -83,6 +83,8 @@ mod montgomery_affine_impl {
         pub fn from_edwards_to_coords(
             p: &TEAffine<P>,
         ) -> Result<(P::BaseField, P::BaseField), SynthesisError> {
+            println!("{}", p.x);
+            println!("{}", p.y);
             let montgomery_point: GroupAffine<P> = if p.y == P::BaseField::one() {
                 GroupAffine::identity()
             } else if p.x == P::BaseField::zero() {
@@ -91,6 +93,9 @@ mod montgomery_affine_impl {
                 let u =
                     (P::BaseField::one() + &p.y) * &(P::BaseField::one() - &p.y).inverse().unwrap();
                 let v = u * &p.x.inverse().unwrap();
+
+                println!("{}", u);
+                println!("{}", v);
                 GroupAffine::new(u, v)
             };
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -38,7 +38,7 @@ pub struct MontgomeryAffineVar<
 
 mod montgomery_affine_impl {
     use super::*;
-    use ark_ec::twisted_edwards::Affine as GroupAffine;
+    use ark_ec::twisted_edwards::MontgomeryAffine as GroupAffine;
     use ark_ff::Field;
     use core::ops::Add;
 
@@ -83,10 +83,8 @@ mod montgomery_affine_impl {
         pub fn from_edwards_to_coords(
             p: &TEAffine<P>,
         ) -> Result<(P::BaseField, P::BaseField), SynthesisError> {
-            println!("{}", p.x);
-            println!("{}", p.y);
-            let montgomery_point: GroupAffine<P> = if p.y == P::BaseField::one() {
-                GroupAffine::identity()
+            let montgomery_point: GroupAffine<P::MontCurveConfig> = if p.y == P::BaseField::one() {
+                return Err(SynthesisError::UnexpectedIdentity);
             } else if p.x == P::BaseField::zero() {
                 GroupAffine::new(P::BaseField::zero(), P::BaseField::zero())
             } else {
@@ -94,12 +92,8 @@ mod montgomery_affine_impl {
                     (P::BaseField::one() + &p.y) * &(P::BaseField::one() - &p.y).inverse().unwrap();
                 let v = u * &p.x.inverse().unwrap();
 
-                println!("{}", u);
-                println!("{}", v);
                 GroupAffine::new(u, v)
             };
-            println!("-----");
-
             Ok((montgomery_point.x, montgomery_point.y))
         }
 


### PR DESCRIPTION
## Description

In the implementation of incomplete Montgomery, we use TE's `GroupAffine` for the intermediate representations. It turns out that ark-ec will refuse to do so, because the coordinates in the Montgomery curve are not valid coordinates for the TE curve.

This PR fixes so, using the appropriate `MontgomeryAffine`. 

Recall that this Montgomery is incomplete---and we require this to be used for only CRS that the possibility of hitting those exceptions is negligible. An explicit error is made when trying to create the point of infinity on the Montgomery curve.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
