### PR TITLE
Change the default field type of the pairing var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-r1cs-std"
-version = "0.3.1"
+version = "0.4.0-alpha.1"
 authors = [ "arkworks contributors" ]
 description = "A standard library for constraint system gadgets"
 homepage = "https://arkworks.rs"
@@ -13,10 +13,10 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-ec = { version = "^0.3.0", default-features = false }
-ark-std = { version = "^0.3.0", default-features = false }
-ark-relations = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "0.4.0-alpha", default-features = false }
+ark-ec = { version = "0.4.0-alpha", default-features = false }
+ark-std = { version = "0.4.0-alpha", default-features = false }
+ark-relations = { version = "0.4.0-alpha", default-features = false }
 
 derivative = { version = "2", features = ["use_core"] }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
@@ -25,16 +25,16 @@ num-traits = {version = "0.2", default-features = false }
 num-integer = { version = "0.1.44", default-features = false }
 
 [dev-dependencies]
-ark-test-curves = { version = "^0.3.0", default-features = false, features = ["bls12_381_scalar_field", "bls12_381_curve", "mnt4_753_scalar_field"] }
-ark-poly = { version = "^0.3.0", default-features = false }
+ark-test-curves = { version = "0.4.0-alpha", default-features = false, features = ["bls12_381_scalar_field", "bls12_381_curve", "mnt4_753_scalar_field"] }
+ark-poly = { version = "0.4.0-alpha", default-features = false }
 paste = "1.0"
-ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false  }
-ark-bls12-381 = { version = "^0.3.0", features = ["curve"], default-features = false  }
-ark-mnt4-298 = { version = "^0.3.0", features = ["curve"], default-features = false  }
-ark-mnt4-753 = { version = "^0.3.0", features = ["curve"], default-features = false  }
-ark-mnt6-298 = { version = "^0.3.0", default-features = false  }
-ark-mnt6-753 = { version = "^0.3.0", default-features = false  }
-ark-pallas = { version = "^0.3.0", features = ["curve"],  default-features = false  }
+ark-bls12-377 = { version = "0.4.0-alpha", features = ["curve"], default-features = false  }
+ark-bls12-381 = { version = "0.4.0-alpha", features = ["curve"], default-features = false  }
+ark-mnt4-298 = { version = "0.4.0-alpha", features = ["curve"], default-features = false  }
+ark-mnt4-753 = { version = "0.4.0-alpha", features = ["curve"], default-features = false  }
+ark-mnt6-298 = { version = "0.4.0-alpha", default-features = false  }
+ark-mnt6-753 = { version = "0.4.0-alpha", default-features = false  }
+ark-pallas = { version = "0.4.0-alpha", features = ["curve"],  default-features = false  }
 
 [features]
 default = ["std"]
@@ -70,19 +70,3 @@ lto = "thin"
 incremental = true
 debug-assertions = true
 debug = true
-
-# To be removed in the new release.
-[patch.crates-io]
-ark-std = { git = "https://github.com/arkworks-rs/std" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
-ark-test-curves = { git = "https://github.com/arkworks-rs/algebra" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves" }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves" }
-ark-mnt4-753 = { git = "https://github.com/arkworks-rs/curves" }
-ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves" }
-ark-mnt6-753 = { git = "https://github.com/arkworks-rs/curves" }
-ark-pallas = { git = "https://github.com/arkworks-rs/curves" }

--- a/src/pairing/mod.rs
+++ b/src/pairing/mod.rs
@@ -14,7 +14,10 @@ pub mod mnt6;
 
 /// Specifies the constraints for computing a pairing in the yybilinear group
 /// `E`.
-pub trait PairingVar<E: Pairing, ConstraintF: Field = <<E as Pairing>::G1 as CurveGroup>::BaseField>
+pub trait PairingVar<
+    E: Pairing,
+    ConstraintF: Field = <<<E as Pairing>::G1 as CurveGroup>::BaseField as Field>::BasePrimeField,
+>
 {
     /// An variable representing an element of `G1`.
     /// This is the R1CS equivalent of `E::G1Projective`.

--- a/src/pairing/mod.rs
+++ b/src/pairing/mod.rs
@@ -11,7 +11,7 @@ pub mod mnt4;
 /// This module implements pairings for MNT6 bilinear groups.
 pub mod mnt6;
 
-/// Specifies the constraints for computing a pairing in the yybilinear group
+/// Specifies the constraints for computing a pairing in the bilinear group
 /// `E`.
 pub trait PairingVar<
     E: Pairing,

--- a/src/pairing/mod.rs
+++ b/src/pairing/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use ark_ec::pairing::Pairing;
-use ark_ec::CurveGroup;
 use ark_ff::Field;
 use ark_relations::r1cs::SynthesisError;
 use core::fmt::Debug;
@@ -16,7 +15,7 @@ pub mod mnt6;
 /// `E`.
 pub trait PairingVar<
     E: Pairing,
-    ConstraintF: Field = <<<E as Pairing>::G1 as CurveGroup>::BaseField as Field>::BasePrimeField,
+    ConstraintF: Field = <<E as Pairing>::BaseField as Field>::BasePrimeField,
 >
 {
     /// An variable representing an element of `G1`.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When fixing the `groth16` library, it seems that the default field type of `PairingVar` is insufficient---we need to use the BasePrimeField. This PR makes an attempt, and will be finalized when we know if it fixes the issue in Groth16.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
