### PR TITLE
Fix for add_many (issue #23)

### DIFF
--- a/src/bits/uint.rs
+++ b/src/bits/uint.rs
@@ -175,8 +175,7 @@ macro_rules! make_uint {
                     assert!($size <= 128);
 
                     assert!(operands.len() >= 1);
-                    assert!($size + (operands.len() as f32).log(2.).ceil() as usize
-                            <= F::MODULUS_BIT_SIZE as usize);
+                    assert!($size + ark_std::log2(operands.len()) <= F::MODULUS_BIT_SIZE);
 
                     if operands.len() == 1 {
                         return Ok(operands[0].clone());

--- a/src/bits/uint.rs
+++ b/src/bits/uint.rs
@@ -175,7 +175,8 @@ macro_rules! make_uint {
                     assert!($size <= 128);
 
                     assert!(operands.len() >= 1);
-                    assert!($size * operands.len() <= F::MODULUS_BIT_SIZE as usize);
+                    assert!($size + (operands.len() as f32).log(2.).ceil() as usize
+                            <= F::MODULUS_BIT_SIZE as usize);
 
                     if operands.len() == 1 {
                         return Ok(operands[0].clone());


### PR DESCRIPTION
## Description
Fixed issue #23. 

## Explanation
An addition of two n-bit number can at most be an n+1-bit number. So for m n-bit numbers, the result will be at most ceil(log2(m)) + n bits long.

I am not sure how to write these unit tests, because group size varies drastically between tested curves, any suggestions are appreciated.
---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
