### PR TITLE
added rotl function

### DIFF
--- a/src/bits/uint.rs
+++ b/src/bits/uint.rs
@@ -137,6 +137,24 @@ macro_rules! make_uint {
                         .map(|v| v.rotate_right(u32::try_from(by).unwrap()));
                     result
                 }
+                
+                /// Rotates `self` to the left by `by` steps, wrapping around.
+                #[tracing::instrument(target = "r1cs", skip(self))]
+                pub fn rotl(&self, by: usize) -> Self {
+                    let mut result = self.clone();
+                    let by = by % $size;
+
+                    let new_bits = self.bits.iter().skip(by).chain(&self.bits).take($size);
+
+                    for (res, new) in result.bits.iter_mut().zip(new_bits) {
+                        *res = new.clone();
+                    }
+
+                    result.value = self
+                        .value
+                        .map(|v| v.rotate_left(u32::try_from(by).unwrap()));
+                    result
+                }
 
                 /// Outputs `self ^ other`.
                 ///


### PR DESCRIPTION
Dear Arkworks team,
As I needed a rotl function myself (and rotating to the right 31 times seemed wasteful), I created a rotl function entirely analogous to the rotr function. Kind regards,
Sam

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
