### PR TITLE
Fix base scalar multiplication

### DIFF
--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -559,7 +559,7 @@ where
             .map(|(b, c)| (b.borrow().clone(), *c))
             .unzip();
         let base = bases[0];
-        *self = Self::constant(base).scalar_mul_le(bits.iter())?;
+        *self += Self::constant(base).scalar_mul_le(bits.iter())?;
         Ok(())
     }
 }

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -134,7 +134,7 @@ pub trait CurveVar<C: CurveGroup, ConstraintF: Field>:
             // else, set self = self;
             result = bit.borrow().select(&self_plus_base, &result)?;
         }
-        *self = result;
+        *self += result;
         Ok(())
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Adds result of base scalar multiplication to self instead of discarding previous value.
This seems to be the expected behaviour and this fixes the implementation of the pedersen hash.

closes: https://github.com/arkworks-rs/crypto-primitives/issues/109

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
