### PR TITLE
Hybrid method for random access/conditional selection from 2^k values

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,4 +6,4 @@ match_block_trailing_comma = true
 use_field_init_shorthand = true
 edition = "2018"
 condense_wildcard_suffixes = true
-merge_imports = true
+imports_granularity="Crate"

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1003,12 +1003,12 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
             index += if x.value()? { 1 } else { 0 };
         }
         let chunk_size = 1 << position.len();
-        let root_vals: Vec<FpVar<F>> = values
+        let root_vals: Vec<Self> = values
             .chunks(chunk_size)
             .map(|chunk| chunk[index].clone())
             .collect();
 
-        let allocated_vars: Vec<FpVar<F>> = root_vals
+        let allocated_vars: Vec<Self> = root_vals
             .iter()
             .zip(lc)
             .map(|(val, lc)| {
@@ -1016,7 +1016,7 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
                 let var = cs.new_lc(lc).unwrap();
                 AllocatedFp::new(Some(v), var, cs.clone()).into()
             })
-            .collect::<Vec<FpVar<F>>>();
+            .collect::<Vec<Self>>();
 
         Ok(allocated_vars)
     }

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -989,36 +989,13 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
         Ok(root + (v, lc))
     }
 
-    fn allocate_vars(
-        values: &[Self],
-        position: &[Boolean<F>],
-        lc: Vec<LinearCombination<F>>,
-    ) -> Result<Vec<Self>, SynthesisError> {
-        let cs = position.cs();
-
-        // index for the chunk
-        let mut index = 0;
-        for x in position {
-            index *= 2;
-            index += if x.value()? { 1 } else { 0 };
-        }
-        let chunk_size = 1 << position.len();
-        let root_vals: Vec<Self> = values
-            .chunks(chunk_size)
-            .map(|chunk| chunk[index].clone())
-            .collect();
-
-        let allocated_vars: Result<Vec<Self>, _> = root_vals
-            .iter()
-            .zip(lc)
-            .map(|(val, lc)| {
-                let v = val.value()?;
-                let var = cs.new_lc(lc)?;
-                Ok(AllocatedFp::new(Some(v), var, cs.clone()).into())
-            })
-            .collect::<Result<Vec<Self>, _>>();
-
-        allocated_vars
+    fn allocate_to_lc(
+        var: Variable,
+        val: &Self,
+        cs: &ConstraintSystemRef<F>,
+    ) -> Result<Self, SynthesisError> {
+        let v = val.value()?;
+        Ok(AllocatedFp::new(Some(v), var, cs.clone()).into())
     }
 }
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -425,8 +425,9 @@ impl<F: PrimeField> AllocatedFp<F> {
         // The high level logic is as follows:
         // We want to check that self - other != 0. We do this by checking that
         // (self - other).inverse() exists. In more detail, we check the following:
-        // If `should_enforce == true`, then we set `multiplier = (self - other).inverse()`,
-        // and check that (self - other) * multiplier == 1. (i.e., that the inverse exists)
+        // If `should_enforce == true`, then we set `multiplier = (self -
+        // other).inverse()`, and check that (self - other) * multiplier == 1.
+        // (i.e., that the inverse exists)
         //
         // If `should_enforce == false`, then we set `multiplier == 0`, and check that
         // (self - other) * 0 == 0, which is always satisfied.

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -985,7 +985,7 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
         lc: &LinearCombination<F>,
     ) -> Result<LinearCombination<F>, SynthesisError> {
         let root: LinearCombination<F> = LinearCombination::zero();
-        let v = val.value().unwrap();
+        let v = val.value()?;
         Ok(root + (v, lc))
     }
 
@@ -1008,17 +1008,17 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
             .map(|chunk| chunk[index].clone())
             .collect();
 
-        let allocated_vars: Vec<Self> = root_vals
+        let allocated_vars: Result<Vec<Self>, _> = root_vals
             .iter()
             .zip(lc)
             .map(|(val, lc)| {
-                let v = val.value().unwrap();
-                let var = cs.new_lc(lc).unwrap();
-                AllocatedFp::new(Some(v), var, cs.clone()).into()
+                let v = val.value()?;
+                let var = cs.new_lc(lc)?;
+                Ok(AllocatedFp::new(Some(v), var, cs.clone()).into())
             })
-            .collect::<Vec<Self>>();
+            .collect::<Result<Vec<Self>, _>>();
 
-        Ok(allocated_vars)
+        allocated_vars
     }
 }
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -980,32 +980,45 @@ impl<F: PrimeField> CondSelectGadget<F> for FpVar<F> {
         }
     }
 
-    #[tracing::instrument(target = "r1cs")]
-    fn conditionally_select_power_of_two_vector(
-        position: &[Boolean<F>],
+    fn add_lc(
+        val: &Self,
+        lc: &LinearCombination<F>,
+    ) -> Result<LinearCombination<F>, SynthesisError> {
+        let root: LinearCombination<F> = LinearCombination::zero();
+        let v = val.value().unwrap();
+        Ok(root + (v, lc))
+    }
+
+    fn allocate_vars(
         values: &[Self],
-    ) -> Result<Self, SynthesisError> {
-        let m = values.len();
-
-        let selector_sums = sum_of_conditions(position)?;
-
+        position: &[Boolean<F>],
+        lc: Vec<LinearCombination<F>>,
+    ) -> Result<Vec<Self>, SynthesisError> {
         let cs = position.cs();
 
-        let mut root: LinearCombination<F> = LinearCombination::zero();
-        for i in 0..m {
-            let v = values[i].value().unwrap();
-            root = &root + (v, &selector_sums[i]);
-        }
-        let result = cs.new_lc(root.clone())?;
-
-        // index for the witness
+        // index for the chunk
         let mut index = 0;
         for x in position {
             index *= 2;
             index += if x.value()? { 1 } else { 0 };
         }
+        let chunk_size = 1 << position.len();
+        let root_vals: Vec<FpVar<F>> = values
+            .chunks(chunk_size)
+            .map(|chunk| chunk[index].clone())
+            .collect();
 
-        Ok(AllocatedFp::new(Some(values[index].value().unwrap()), result, cs.clone()).into())
+        let allocated_vars: Vec<FpVar<F>> = root_vals
+            .iter()
+            .zip(lc)
+            .map(|(val, lc)| {
+                let v = val.value().unwrap();
+                let var = cs.new_lc(lc).unwrap();
+                AllocatedFp::new(Some(v), var, cs.clone()).into()
+            })
+            .collect::<Vec<FpVar<F>>>();
+
+        Ok(allocated_vars)
     }
 }
 

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -21,7 +21,8 @@ pub mod quadratic_extension;
 pub mod fp;
 
 /// This module contains a generic implementation of "nonnative" prime field
-/// variables. It emulates `Fp` arithmetic using `Fq` operations, where `p != q`.
+/// variables. It emulates `Fp` arithmetic using `Fq` operations, where `p !=
+/// q`.
 pub mod nonnative;
 
 /// This module contains a generic implementation of the degree-12 tower

--- a/src/fields/nonnative/allocated_field_var.rs
+++ b/src/fields/nonnative/allocated_field_var.rs
@@ -634,10 +634,10 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
     }
 
     /// Allocates a new non-native field witness with value given by the
-    /// function `f`.  Enforces that the field element has value in `[0, modulus)`,
-    /// and returns the bits of its binary representation.
-    /// The bits are in little-endian (i.e., the bit at index 0 is the LSB) and the
-    /// bit-vector is empty in non-witness allocation modes.
+    /// function `f`.  Enforces that the field element has value in `[0,
+    /// modulus)`, and returns the bits of its binary representation.
+    /// The bits are in little-endian (i.e., the bit at index 0 is the LSB) and
+    /// the bit-vector is empty in non-witness allocation modes.
     pub fn new_witness_with_le_bits<T: Borrow<TargetField>>(
         cs: impl Into<Namespace<BaseField>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,

--- a/src/pairing/mod.rs
+++ b/src/pairing/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-use ark_ec::pairing::Pairing;
-use ark_ec::CurveGroup;
+use ark_ec::{pairing::Pairing, CurveGroup};
 use ark_ff::Field;
 use ark_relations::r1cs::SynthesisError;
 use core::fmt::Debug;

--- a/src/select.rs
+++ b/src/select.rs
@@ -37,17 +37,6 @@ where
     }
 }
 
-fn count_ones(x: usize) -> usize {
-    // count the number of 1s in the binary representation of x
-    let mut count = 0;
-    let mut y = x;
-    while y > 0 {
-        count += y & 1;
-        y >>= 1;
-    }
-    count
-}
-
 /// Sum of conditions method 5.2 from https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf
 /// Use this to generate the selector sums.
 pub fn sum_of_conditions<ConstraintF: Field>(
@@ -88,6 +77,17 @@ pub fn sum_of_conditions<ConstraintF: Field>(
         for j in (1 << i) + 1..(1 << (i + 1)) {
             selectors[j] = selectors[1 << i].and(&selectors[j - (1 << i)])?;
         }
+    }
+
+    fn count_ones(x: usize) -> usize {
+        // count the number of 1s in the binary representation of x
+        let mut count = 0;
+        let mut y = x;
+        while y > 0 {
+            count += y & 1;
+            y >>= 1;
+        }
+        count
     }
 
     // Selector sums for each leaf node

--- a/src/select.rs
+++ b/src/select.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use ark_ff::Field;
 use ark_relations::r1cs::{LinearCombination, SynthesisError};
 use ark_std::vec::Vec;
-/// Generates constraints for selecting between one of two values.
+/// Generates constraints for selecting between one of many values.
 pub trait CondSelectGadget<ConstraintF: Field>
 where
     Self: Sized,

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use ark_ff::Field;
-use ark_relations::r1cs::SynthesisError;
+use ark_relations::r1cs::{LinearCombination, SynthesisError};
 use ark_std::vec::Vec;
 /// Generates constraints for selecting between one of two values.
 pub trait CondSelectGadget<ConstraintF: Field>
@@ -32,8 +32,100 @@ where
         position: &[Boolean<ConstraintF>],
         values: &[Self],
     ) -> Result<Self, SynthesisError> {
+        let _ = sum_of_conditions(position, values);
         repeated_selection(position, values)
     }
+}
+
+fn count_ones(x: usize) -> usize {
+    // count the number of 1s in the binary representation of x
+    let mut count = 0;
+    let mut y = x;
+    while y > 0 {
+        count += y & 1;
+        y >>= 1;
+    }
+    count
+}
+
+/// Sum of conditions method 5.2 from https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf
+fn sum_of_conditions<ConstraintF: Field, CondG: CondSelectGadget<ConstraintF>>(
+    position: &[Boolean<ConstraintF>],
+    values: &[CondG],
+) -> Result<CondG, SynthesisError> {
+    let m = values.len();
+    let n = position.len();
+
+    // Assert m is a power of 2, and n = log(m)
+    assert!(m.is_power_of_two());
+    assert_eq!(1 << n, m);
+
+    let mut selectors: Vec<LinearCombination<ConstraintF>> = Vec::with_capacity(m);
+
+    // fill the selectors vec with Boolean true entries
+    for _ in 0..m {
+        selectors.push(Boolean::constant(true).lc());
+    }
+
+    // let's construct the table of selectors.
+    // for a bit-decomposition (b_{n-1}, b_{n-2}, ..., b_0) of `power`:
+    // [
+    //      (b_{n-1} * b_{n-2} * ... * b_1 * b_0),
+    //      (b_{n-1} * b_{n-2} * ... * b_1),
+    //      (b_{n-1} * b_{n-2} * ... * b_0),
+    //      ...
+    //      (b_1 * b_0),
+    //      b_1,
+    //      b_0,
+    //      1,
+    // ]
+    // signal selectors[leafCount];
+    //
+    // the element of the selector table at index i is a product of `bits`
+    // e.g. for i = 5 == (101)_binary
+    // `selectors[5]` <== b_2 * b_0`
+    // we can construct the first `max_bits_in_power - 1` elements without products,
+    // directly from `bits`:
+    // e.g. for
+    // `selectors[1] <== b_0`
+    // `selectors[2] <== b_1`
+    // `selectors[4] <== b_2`
+    // `selectors[8] <== b_3`
+
+    // First element is true, but we've already filled it in.
+    // selectors[0] = Boolean::constant(true);
+    for i in 0..n {
+        selectors[1 << i] = position[i].lc();
+        for j in (1 << i) + 1..(1 << (i + 1)) {
+            selectors[j] = &selectors[1 << i] + &selectors[j - (1 << i)];
+        }
+    }
+
+    let mut selector_sums: Vec<LinearCombination<ConstraintF>> = Vec::with_capacity(m);
+    for i in 0..m {
+        for j in 0..m {
+            if i | j == j {
+                let counts = count_ones(j - i);
+                if counts % 2 == 0 {
+                    selector_sums[i] = &selector_sums[i] + &selectors[j];
+                } else {
+                    selector_sums[i] = &selector_sums[i] - &selectors[j];
+                };
+            }
+        }
+    }
+
+    let root: LinearCombination<ConstraintF> = LinearCombination::zero();
+    // var x = 0;
+    for i in 0..m {
+        root = &root + (values[i], selector_sums[i]);
+    }
+    // for (var i = 0; i < nextPow; i++) {
+    //     x += leaves[i] * selector_sums[i];
+    // }
+    // root <== x;
+
+    unimplemented!()
 }
 
 /// Repeated selection method 5.1 from https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Create `O(sqrt(n))` instead of `O(n)` constraints as per https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf.

By trying to make this as generic as possible, I had to add two extra methods on the trait, which for now are only implemented for `FpVar` for testing.
@arkworks-rs/maintainers do you see a way to NOT introduce these extra methods? I tried adding a trait bound for `AllocVar` to `CondSelectGadget`, but going down that rabbit hole hasn't worked so far.

### Benches:
for `k=7`, `2^7=128` values

1. Repeated-selection 5.1, O(n): 

- expecting`2^(k-1) - 1` constraints
```
cond_select takes: 63 constraints, 347 non-zeros
```


2. Hybrid method 5.3, O(sqrt(n)): 
- expect `2^m + 2^l - l - 2` constraints
- `m = k/2 = 3`; `l = 4`; `2^3 + 2^4 - 4 - 2 = 18`

```
cond_select takes: 18 constraints, 184 non-zeros
```

as expected.


closes: #118 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
