### PR TITLE
alloc zero points consistently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-test-curves = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-bn254 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves/" }

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -211,8 +211,13 @@ where
             Ok(ge) => {
                 let ge = ge.into_affine();
                 if ge.is_zero() {
-                    let zero = SWProjective::<P>::zero();
-                    (Ok(zero.x), Ok(zero.y), Ok(zero.z))
+                    // These values are convenient since the point satisfies
+                    // curve equation.
+                    (
+                        Ok(P::BaseField::zero()),
+                        Ok(P::BaseField::one()),
+                        Ok(P::BaseField::zero()),
+                    )
                 } else {
                     (Ok(ge.x), Ok(ge.y), Ok(P::BaseField::one()))
                 }
@@ -379,7 +384,7 @@ where
     }
 
     fn zero() -> Self {
-        Self::constant(SWProjective::<P>::zero())
+        Self::new(F::zero(), F::one(), F::zero())
     }
 
     fn is_zero(&self) -> Result<Boolean<<P::BaseField as Field>::BasePrimeField>, SynthesisError> {

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -337,10 +337,10 @@ where
         for bit in affine_bits.iter().skip(1) {
             if bit.is_constant() {
                 if *bit == &Boolean::TRUE {
-                    accumulator = accumulator.add_unchecked(&multiple_of_power_of_two)?;
+                    accumulator = accumulator.add_unchecked(multiple_of_power_of_two)?;
                 }
             } else {
-                let temp = accumulator.add_unchecked(&multiple_of_power_of_two)?;
+                let temp = accumulator.add_unchecked(multiple_of_power_of_two)?;
                 accumulator = bit.select(&temp, &accumulator)?;
             }
             multiple_of_power_of_two.double_in_place()?;

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -170,8 +170,9 @@ where
         } else {
             let cs = self.cs();
             let infinity = self.is_zero()?;
-            let zero_x = F::zero();
-            let zero_y = F::one();
+            let zero_affine = SWAffine::<P>::zero();
+            let zero_x = F::new_constant(cs.clone(), &zero_affine.x)?;
+            let zero_y = F::new_constant(cs.clone(), &zero_affine.y)?;
             // Allocate a variable whose value is either `self.z.inverse()` if the inverse
             // exists, and is zero otherwise.
             let z_inv = F::new_witness(ark_relations::ns!(cs, "z_inverse"), || {
@@ -210,11 +211,8 @@ where
             Ok(ge) => {
                 let ge = ge.into_affine();
                 if ge.is_zero() {
-                    (
-                        Ok(P::BaseField::zero()),
-                        Ok(P::BaseField::one()),
-                        Ok(P::BaseField::zero()),
-                    )
+                    let zero = SWProjective::<P>::zero();
+                    (Ok(zero.x), Ok(zero.y), Ok(zero.z))
                 } else {
                     (Ok(ge.x), Ok(ge.y), Ok(P::BaseField::one()))
                 }
@@ -381,7 +379,7 @@ where
     }
 
     fn zero() -> Self {
-        Self::new(F::zero(), F::one(), F::zero())
+        Self::constant(SWProjective::<P>::zero())
     }
 
     fn is_zero(&self) -> Result<Boolean<<P::BaseField as Field>::BasePrimeField>, SynthesisError> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fix for https://github.com/arkworks-rs/crypto-primitives/pull/115

(0, 1) point is valid affine zero for twisted edwards curve, but this code is for short weierstrass.
This causes inconsistency in poseidon sponge usage.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
