### PR TITLE
convert nonnative constant to little endian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 - [\#117](https://github.com/arkworks-rs/r1cs-std/pull/117) Fix result of `precomputed_base_scalar_mul_le` to not discard previous value.
 - [\#124](https://github.com/arkworks-rs/r1cs-std/pull/124) Fix `scalar_mul_le` constraints unsatisfiability when short Weierstrass point is zero.
+- [\#127](https://github.com/arkworks-rs/r1cs-std/pull/127) Convert `NonNativeFieldVar` constants to little-endian bytes instead of big-endian (`ToBytesGadget`).
 
 ### Breaking changes
 

--- a/src/fields/nonnative/field_var.rs
+++ b/src/fields/nonnative/field_var.rs
@@ -313,7 +313,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
     fn to_bytes(&self) -> R1CSResult<Vec<UInt8<BaseField>>> {
         match self {
             Self::Constant(c) => Ok(UInt8::constant_vec(
-                c.into_bigint().to_bytes_be().as_slice(),
+                c.into_bigint().to_bytes_le().as_slice(),
             )),
 
             Self::Var(v) => v.to_bytes(),
@@ -324,7 +324,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
     fn to_non_unique_bytes(&self) -> R1CSResult<Vec<UInt8<BaseField>>> {
         match self {
             Self::Constant(c) => Ok(UInt8::constant_vec(
-                c.into_bigint().to_bytes_be().as_slice(),
+                c.into_bigint().to_bytes_le().as_slice(),
             )),
             Self::Var(v) => v.to_non_unique_bytes(),
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Non native constants should be converted to little endian bytes instead of big endian.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
