### PR TITLE
make nonnative gadget params configurable

### DIFF
--- a/src/fields/nonnative/mul_result.rs
+++ b/src/fields/nonnative/mul_result.rs
@@ -1,4 +1,7 @@
-use super::{AllocatedNonNativeFieldMulResultVar, NonNativeFieldVar};
+use super::{
+    params::{DefaultParams, Params},
+    AllocatedNonNativeFieldMulResultVar, NonNativeFieldVar,
+};
 use ark_ff::PrimeField;
 use ark_relations::r1cs::Result as R1CSResult;
 
@@ -12,15 +15,19 @@ use ark_relations::r1cs::Result as R1CSResult;
 /// This may help cut the number of reduce operations.
 #[derive(Debug)]
 #[must_use]
-pub enum NonNativeFieldMulResultVar<TargetField: PrimeField, BaseField: PrimeField> {
+pub enum NonNativeFieldMulResultVar<
+    TargetField: PrimeField,
+    BaseField: PrimeField,
+    P: Params = DefaultParams,
+> {
     /// as a constant
     Constant(TargetField),
     /// as an allocated gadget
-    Var(AllocatedNonNativeFieldMulResultVar<TargetField, BaseField>),
+    Var(AllocatedNonNativeFieldMulResultVar<TargetField, BaseField, P>),
 }
 
-impl<TargetField: PrimeField, BaseField: PrimeField>
-    NonNativeFieldMulResultVar<TargetField, BaseField>
+impl<TargetField: PrimeField, BaseField: PrimeField, P: Params>
+    NonNativeFieldMulResultVar<TargetField, BaseField, P>
 {
     /// Create a zero `NonNativeFieldMulResultVar` (used for additions)
     pub fn zero() -> Self {
@@ -34,7 +41,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
 
     /// Reduce the `NonNativeFieldMulResultVar` back to NonNativeFieldVar
     #[tracing::instrument(target = "r1cs")]
-    pub fn reduce(&self) -> R1CSResult<NonNativeFieldVar<TargetField, BaseField>> {
+    pub fn reduce(&self) -> R1CSResult<NonNativeFieldVar<TargetField, BaseField, P>> {
         match self {
             Self::Constant(c) => Ok(NonNativeFieldVar::Constant(*c)),
             Self::Var(v) => Ok(NonNativeFieldVar::Var(v.reduce()?)),
@@ -42,17 +49,18 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
     }
 }
 
-impl<TargetField: PrimeField, BaseField: PrimeField>
-    From<&NonNativeFieldVar<TargetField, BaseField>>
-    for NonNativeFieldMulResultVar<TargetField, BaseField>
+impl<TargetField: PrimeField, BaseField: PrimeField, P: Params>
+    From<&NonNativeFieldVar<TargetField, BaseField, P>>
+    for NonNativeFieldMulResultVar<TargetField, BaseField, P>
 {
-    fn from(src: &NonNativeFieldVar<TargetField, BaseField>) -> Self {
+    fn from(src: &NonNativeFieldVar<TargetField, BaseField, P>) -> Self {
         match src {
             NonNativeFieldVar::Constant(c) => NonNativeFieldMulResultVar::Constant(*c),
             NonNativeFieldVar::Var(v) => {
                 NonNativeFieldMulResultVar::Var(AllocatedNonNativeFieldMulResultVar::<
                     TargetField,
                     BaseField,
+                    P,
                 >::from(v))
             },
         }
@@ -60,13 +68,13 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
 }
 
 impl_bounded_ops!(
-    NonNativeFieldMulResultVar<TargetField, BaseField>,
+    NonNativeFieldMulResultVar<TargetField, BaseField, P>,
     TargetField,
     Add,
     add,
     AddAssign,
     add_assign,
-    |this: &'a NonNativeFieldMulResultVar<TargetField, BaseField>, other: &'a NonNativeFieldMulResultVar<TargetField, BaseField>| {
+    |this: &'a NonNativeFieldMulResultVar<TargetField, BaseField, P>, other: &'a NonNativeFieldMulResultVar<TargetField, BaseField, P>| {
         use NonNativeFieldMulResultVar::*;
         match (this, other) {
             (Constant(c1), Constant(c2)) => Constant(*c1 + c2),
@@ -74,6 +82,6 @@ impl_bounded_ops!(
             (Var(v1), Var(v2)) => Var(v1.add(v2).unwrap()),
         }
     },
-    |this: &'a NonNativeFieldMulResultVar<TargetField, BaseField>, other: TargetField| { this + &NonNativeFieldMulResultVar::Constant(other) },
-    (TargetField: PrimeField, BaseField: PrimeField),
+    |this: &'a NonNativeFieldMulResultVar<TargetField, BaseField, P>, other: TargetField| { this + &NonNativeFieldMulResultVar::Constant(other) },
+    (TargetField: PrimeField, BaseField: PrimeField, P: Params),
 );

--- a/src/fields/nonnative/params.rs
+++ b/src/fields/nonnative/params.rs
@@ -1,4 +1,34 @@
+use ark_ff::PrimeField;
+use ark_std::fmt;
+
 use super::NonNativeFieldConfig;
+
+/// Type that provides non native arithmetic configuration for a given pair of fields
+/// and optimization goal.
+pub trait Params: fmt::Debug + 'static {
+    /// Provide non native parameters.
+    ///
+    /// This function should be pure -- return the same config for the same input.
+    fn get<TargetField: PrimeField, BaseField: PrimeField>(
+        optimization_type: OptimizationType,
+    ) -> NonNativeFieldConfig;
+}
+
+/// Default parameters implementation based on [`find_parameters`].
+#[derive(Debug)]
+pub struct DefaultParams;
+
+impl Params for DefaultParams {
+    fn get<TargetField: PrimeField, BaseField: PrimeField>(
+        optimization_type: OptimizationType,
+    ) -> NonNativeFieldConfig {
+        get_params(
+            TargetField::MODULUS_BIT_SIZE as usize,
+            BaseField::MODULUS_BIT_SIZE as usize,
+            optimization_type,
+        )
+    }
+}
 
 /// Obtain the parameters from a `ConstraintSystem`'s cache or generate a new
 /// one

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -1018,7 +1018,10 @@ mod test_sw_curve {
             ProjectiveVar::<G::Config, FpVar<G::BaseField>>::new_input(cs.clone(), || {
                 Ok(point_out)
             })?;
-        let scalar = NonNativeFieldVar::new_input(cs.clone(), || Ok(scalar))?;
+        let scalar =
+            NonNativeFieldVar::<G::ScalarField, G::BaseField>::new_input(cs.clone(), || {
+                Ok(scalar)
+            })?;
 
         let mul = point_in.scalar_mul_le(scalar.to_bits_le().unwrap().iter())?;
 

--- a/tests/to_constraint_field_test.rs
+++ b/tests/to_constraint_field_test.rs
@@ -10,8 +10,8 @@ fn to_constraint_field_test() {
 
     let cs = ConstraintSystem::<CF>::new_ref();
 
-    let a = NonNativeFieldVar::Constant(F::from(12u8));
-    let b = NonNativeFieldVar::new_input(cs.clone(), || Ok(F::from(6u8))).unwrap();
+    let a = NonNativeFieldVar::<F, CF>::Constant(F::from(12u8));
+    let b = NonNativeFieldVar::<F, CF>::new_input(cs.clone(), || Ok(F::from(6u8))).unwrap();
 
     let b2 = &b + &b;
 


### PR DESCRIPTION
Depending on a goal, some developers would want to have a specific configuration perhaps with a smaller number
of limbs.

This change is **almost** backwards compatible and actually breaks some code in `ark-crypto-primitives`,
but it tries to follow the pattern from Rust std like "Vec<T, A: Allocator **= Globa**l>"

Hence the new definition
```rust
pub enum NonNativeFieldVar<
    TargetField: PrimeField,
    BaseField: PrimeField,
    P: Params = DefaultParams, // <-- opt in to define your own.
> {
    /// Constant
    Constant(TargetField),
    /// Allocated gadget
    Var(AllocatedNonNativeFieldVar<TargetField, BaseField, P>),
}
```
Likewise for `AllocatedNonNativeFieldVar`, `NonNativeFieldMulResultVar`, `AllocatedNonNativeFieldMulResultVar`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
