### PR TITLE
Case for fallible `cs()` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iterator_try_reduce)]
 #![cfg_attr(not(feature = "std"), no_std)]
 //! This crate implements common "gadgets" that make
 //! programming rank-1 constraint systems easier.
@@ -131,12 +132,31 @@ pub trait R1CSVar<F: Field> {
 impl<F: Field, T: R1CSVar<F>> R1CSVar<F> for [T] {
     type Value = Vec<T::Value>;
 
-    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<F> {
-        let mut result = ark_relations::r1cs::ConstraintSystemRef::None;
-        for var in self {
-            result = var.cs().or(result);
+    fn cs(&self) -> Result<ark_relations::r1cs::ConstraintSystemRef<F>, &str> {
+        if let Some(Ok(result)) = self.iter().map(|x| Ok(x.cs())).reduce(
+            |x: Result<ark_relations::r1cs::ConstraintSystemRef<F>, _>, y| {
+                if let Ok(x) = x {
+                    let y = y?;
+                    if x != y {
+                        if x.is_none() {
+                            return Ok(y);
+                        }
+                        if y.is_none() {
+                            return Ok(x);
+                        }
+                        Err("todo!(CSs are not reducible to one)")
+                    } else {
+                        return Ok(x);
+                    }
+                } else {
+                    x
+                }
+            },
+        ) {
+            Ok(result.to_owned())
+        } else {
+            Err("empty input")
         }
-        result
     }
 
     fn value(&self) -> Result<Self::Value, ark_relations::r1cs::SynthesisError> {


### PR DESCRIPTION
Error handling is mocked just for example; return type for the modified method have been left incompatible as it shows the idea to the point.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
It's a small example on possible inconsistency when `cs()` is called on `[T]` which contains different non-null CS. I'd like to continue on this one if introduction of error handling is indeed reasonable in the crate; or receive feedback showing this is a bad idea.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

Unchecked boxes are due to the draft nature of this PR and it's purpose isn't merging but feedback to continue development in this direction.