### PR TITLE
Add `ToConstraintFieldGadget` bounds to `CurveVar` and `FieldVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
     - Add `UInt::rotate_{left,right}_in_place`.
     - Add `{Boolean,UInt}::not_in_place`.
     - Add `UInt::{from_bytes_le, from_bytes_be, to_bytes_be}`.
+- [\#144](https://github.com/arkworks-rs/r1cs-std/pull/144)
+    - Add `ToConstraintFieldGadget` bounds to `CurveVar` and `FieldVar`
 
 ### Improvements
 

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -5,7 +5,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-use crate::convert::{ToBitsGadget, ToBytesGadget};
+use crate::convert::{ToBitsGadget, ToBytesGadget, ToConstraintFieldGadget};
 use crate::prelude::*;
 
 /// This module contains a generic implementation of cubic extension field
@@ -76,6 +76,7 @@ pub trait FieldVar<F: Field, ConstraintF: PrimeField>:
     + AllocVar<F, ConstraintF>
     + ToBytesGadget<ConstraintF>
     + CondSelectGadget<ConstraintF>
+    + ToConstraintFieldGadget<ConstraintF>
     + for<'a> FieldOpsBounds<'a, F, Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    convert::{ToBitsGadget, ToBytesGadget},
+    convert::{ToBitsGadget, ToBytesGadget, ToConstraintFieldGadget},
     fields::emulated_fp::EmulatedFpVar,
     prelude::*,
 };
@@ -41,6 +41,7 @@ pub trait CurveVar<C: CurveGroup, ConstraintF: PrimeField>:
     + CondSelectGadget<ConstraintF>
     + AllocVar<C, ConstraintF>
     + AllocVar<C::Affine, ConstraintF>
+    + ToConstraintFieldGadget<ConstraintF>
     + for<'a> GroupOpsBounds<'a, C, Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds the requirement that structs that implement `CurveVar` or `FieldVar` should also implement `ToConstraintFieldGadget`, which could be convenient e.g. when we want to extract the underlying `FpVar`s from a generic `CurveVar` without specifying `+ ToConstraintFieldGadget<...>` every time.

Since both implementations of `CurveVar` (i.e., SW `ProjectiveVar` and TE `AffineVar`) and all implementations of `FieldVar` (i.e., `FpVar`, `QuadExtVar`, `CubicExtVar`, and `EmulatedFpVar`) already implement `ToConstraintFieldGadget` as well, this PR does not introduce any change in the behavior of existing code.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (N/A)
- [ ] Updated relevant documentation in the code (N/A)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
