### PR TITLE
Avoid deeply nested `LinearCombination`s in `EvaluationsVar::interpolate_and_evaluate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 
 ### Bug Fixes
 
+- [\#145](https://github.com/arkworks-rs/r1cs-std/pull/145)
+    - Avoid deeply nested `LinearCombinations` in `EvaluationsVar::interpolate_and_evaluate` to fix the stack overflow issue when calling `.value()` on the evaluation result.
+
 ## 0.4.0
 
 - [\#117](https://github.com/arkworks-rs/r1cs-std/pull/117) Fix result of `precomputed_base_scalar_mul_le` to not discard previous value.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

It is observed in https://github.com/privacy-scaling-explorations/sonobe/issues/80 that stack overflow occurs when calling `EvaluationsVar::interpolate_and_evaluate` for large evaluation domains (e.g., when $n > 11$).

I think this happens because in [`EvaluationsVar::lagrange_interpolate_with_constant_offset`](https://github.com/arkworks-rs/r1cs-std/blob/4020fbc22625621baa8125ede87abaeac3c1ca26/src/poly/evaluations/univariate/mod.rs#L152-L168) and [`EvaluationsVar::lagrange_interpolate_with_non_constant_offset`](https://github.com/arkworks-rs/r1cs-std/blob/4020fbc22625621baa8125ede87abaeac3c1ca26/src/poly/evaluations/univariate/mod.rs#L172-L239), we are updating the final evaluation result in a for loop, and `+=` in each iteration wraps the current result by a new layer of `LinearCombination`. This produces a deeply nested `LinearCombination`. When we get `.value()` of the evaluation result, internally [`ConstraintSystem::assigned_value`](https://github.com/arkworks-rs/snark/blob/0759f942e18eb73fc2b5da2ee58d2994d3dc557d/relations/src/r1cs/constraint_system.rs#L627-L644) is invoked to recursively flatten the LC. Unfortunately, the number of LC layers of the evaluation result is so large that the recursion depth exceeds the OS limit, resulting in a stack overflow.

This PR fixes the above bug by calling `.sum()` on the iterator of addends, since this method invokes [`‎AllocatedFp::add_many`](https://github.com/arkworks-rs/r1cs-std/blob/4020fbc22625621baa8125ede87abaeac3c1ca26/src/fields/fp/mod.rs#L163-L192), which produces a flat LC.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code (N/A)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
