### PR TITLE
Replace derivative with educe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        id: toolchain-thumbv6m
-        with:
-          target: thumbv6m-none-eabi
-      - run: rustup override set ${{steps.toolchain-thumbv6m.outputs.name}}
-
       - name: Install Rust ARM64
         uses: dtolnay/rust-toolchain@stable
         id: toolchain-aarch64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,4 @@ ark-mnt4-753 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-mnt6-753 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-pallas = { git = "https://github.com/arkworks-rs/curves/" }
+ark-std = { git = "https://github.com/arkworks-rs/std/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ark-ec = { version = "0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 ark-relations = { version = "0.4.0", default-features = false }
 
-derivative = { version = "2", features = ["use_core"] }
+educe = "0.6.0"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 num-bigint = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ incremental = true
 debug-assertions = true
 debug = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
+
 [patch.crates-io]
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }

--- a/src/fields/cubic_extension.rs
+++ b/src/fields/cubic_extension.rs
@@ -1,21 +1,21 @@
-use ark_ff::{
-    fields::{CubicExtField, Field},
-    CubicExtConfig, Zero,
-};
-use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-use core::{borrow::Borrow, marker::PhantomData};
-
 use crate::{
     convert::{ToBitsGadget, ToBytesGadget, ToConstraintFieldGadget},
     fields::{fp::FpVar, FieldOpsBounds, FieldVar},
     prelude::*,
     Vec,
 };
+use ark_ff::{
+    fields::{CubicExtField, Field},
+    CubicExtConfig, Zero,
+};
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+use core::{borrow::Borrow, marker::PhantomData};
+use educe::Educe;
 
 /// This struct is the `R1CS` equivalent of the cubic extension field type
 /// in `ark-ff`, i.e. `ark_ff::CubicExtField`.
-#[derive(Derivative)]
-#[derivative(Debug(bound = "BF: core::fmt::Debug"), Clone(bound = "BF: Clone"))]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct CubicExtVar<BF: FieldVar<P::BaseField, P::BasePrimeField>, P: CubicExtVarConfig<BF>>
 where
@@ -27,7 +27,7 @@ where
     pub c1: BF,
     /// The second coefficient of this field element.
     pub c2: BF,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 

--- a/src/fields/quadratic_extension.rs
+++ b/src/fields/quadratic_extension.rs
@@ -1,21 +1,21 @@
-use ark_ff::{
-    fields::{Field, QuadExtConfig, QuadExtField},
-    Zero,
-};
-use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-use core::{borrow::Borrow, marker::PhantomData};
-
 use crate::{
     convert::{ToBitsGadget, ToBytesGadget, ToConstraintFieldGadget},
     fields::{fp::FpVar, FieldOpsBounds, FieldVar},
     prelude::*,
     Vec,
 };
+use ark_ff::{
+    fields::{Field, QuadExtConfig, QuadExtField},
+    Zero,
+};
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+use core::{borrow::Borrow, marker::PhantomData};
+use educe::Educe;
 
 /// This struct is the `R1CS` equivalent of the quadratic extension field type
 /// in `ark-ff`, i.e. `ark_ff::QuadExtField`.
-#[derive(Derivative)]
-#[derivative(Debug(bound = "BF: core::fmt::Debug"), Clone(bound = "BF: Clone"))]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct QuadExtVar<BF: FieldVar<P::BaseField, P::BasePrimeField>, P: QuadExtVarConfig<BF>>
 where
@@ -25,7 +25,7 @@ where
     pub c0: BF,
     /// The first coefficient of this field element.
     pub c1: BF,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 

--- a/src/groups/curves/short_weierstrass/bls12/mod.rs
+++ b/src/groups/curves/short_weierstrass/bls12/mod.rs
@@ -10,7 +10,6 @@ use crate::{
     groups::curves::short_weierstrass::*,
     Vec,
 };
-use core::fmt::Debug;
 
 /// Represents a projective point in G1.
 pub type G1Var<P> = ProjectiveVar<<P as Bls12Config>::G1Config, FpVar<<P as Bls12Config>::Fp>>;
@@ -29,8 +28,8 @@ pub type G2AffineVar<P> = AffineVar<<P as Bls12Config>::G2Config, Fp2G<P>>;
 
 /// Represents the cached precomputation that can be performed on a G1 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "G1Var<P>: Clone"), Debug(bound = "G1Var<P>: Debug"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G1PreparedVar<P: Bls12Config>(pub AffineVar<P::G1Config, FpVar<P::Fp>>);
 
 impl<P: Bls12Config> G1PreparedVar<P> {
@@ -103,11 +102,8 @@ type Fp2G<P> = Fp2Var<<P as Bls12Config>::Fp2Config>;
 type LCoeff<P> = (Fp2G<P>, Fp2G<P>);
 /// Represents the cached precomputation that can be performed on a G2 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(
-    Clone(bound = "Fp2Var<P::Fp2Config>: Clone"),
-    Debug(bound = "Fp2Var<P::Fp2Config>: Debug")
-)]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G2PreparedVar<P: Bls12Config> {
     #[doc(hidden)]
     pub ell_coeffs: Vec<LCoeff<P>>,

--- a/src/groups/curves/short_weierstrass/mnt4/mod.rs
+++ b/src/groups/curves/short_weierstrass/mnt4/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     Vec,
 };
 use core::borrow::Borrow;
+use educe::Educe;
 
 /// Represents a projective point in G1.
 pub type G1Var<P> = ProjectiveVar<<P as MNT4Config>::G1Config, FpVar<<P as MNT4Config>::Fp>>;
@@ -23,8 +24,8 @@ pub type G2Var<P> = ProjectiveVar<<P as MNT4Config>::G2Config, Fp2G<P>>;
 
 /// Represents the cached precomputation that can be performed on a G1 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT4Config"), Debug(bound = "P: MNT4Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G1PreparedVar<P: MNT4Config> {
     #[doc(hidden)]
     pub x: FpVar<P::Fp>,
@@ -135,8 +136,8 @@ type Fp2G<P> = Fp2Var<<P as MNT4Config>::Fp2Config>;
 
 /// Represents the cached precomputation that can be performed on a G2 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT4Config"), Debug(bound = "P: MNT4Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G2PreparedVar<P: MNT4Config> {
     #[doc(hidden)]
     pub x: Fp2Var<P::Fp2Config>,
@@ -340,8 +341,8 @@ impl<P: MNT4Config> G2PreparedVar<P> {
 }
 
 #[doc(hidden)]
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT4Config"), Debug(bound = "P: MNT4Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct AteDoubleCoefficientsVar<P: MNT4Config> {
     pub c_h: Fp2Var<P::Fp2Config>,
     pub c_4c: Fp2Var<P::Fp2Config>,
@@ -425,8 +426,8 @@ impl<P: MNT4Config> AteDoubleCoefficientsVar<P> {
 }
 
 #[doc(hidden)]
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT4Config"), Debug(bound = "P: MNT4Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct AteAdditionCoefficientsVar<P: MNT4Config> {
     pub c_l1: Fp2Var<P::Fp2Config>,
     pub c_rz: Fp2Var<P::Fp2Config>,

--- a/src/groups/curves/short_weierstrass/mnt6/mod.rs
+++ b/src/groups/curves/short_weierstrass/mnt6/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     Vec,
 };
 use core::borrow::Borrow;
+use educe::Educe;
 
 /// Represents a projective point in G1.
 pub type G1Var<P> = ProjectiveVar<<P as MNT6Config>::G1Config, FpVar<<P as MNT6Config>::Fp>>;
@@ -23,8 +24,8 @@ pub type G2Var<P> = ProjectiveVar<<P as MNT6Config>::G2Config, Fp3G<P>>;
 
 /// Represents the cached precomputation that can be performed on a G1 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT6Config"), Debug(bound = "P: MNT6Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G1PreparedVar<P: MNT6Config> {
     #[doc(hidden)]
     pub x: FpVar<P::Fp>,
@@ -135,8 +136,8 @@ type Fp3G<P> = Fp3Var<<P as MNT6Config>::Fp3Config>;
 
 /// Represents the cached precomputation that can be performed on a G2 element
 /// which enables speeding up pairing computation.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT6Config"), Debug(bound = "P: MNT6Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct G2PreparedVar<P: MNT6Config> {
     #[doc(hidden)]
     pub x: Fp3Var<P::Fp3Config>,
@@ -340,8 +341,8 @@ impl<P: MNT6Config> G2PreparedVar<P> {
 }
 
 #[doc(hidden)]
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT6Config"), Debug(bound = "P: MNT6Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct AteDoubleCoefficientsVar<P: MNT6Config> {
     pub c_h: Fp3Var<P::Fp3Config>,
     pub c_4c: Fp3Var<P::Fp3Config>,
@@ -423,8 +424,8 @@ impl<P: MNT6Config> AteDoubleCoefficientsVar<P> {
 }
 
 #[doc(hidden)]
-#[derive(Derivative)]
-#[derivative(Clone(bound = "P: MNT6Config"), Debug(bound = "P: MNT6Config"))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct AteAdditionCoefficientsVar<P: MNT6Config> {
     pub c_l1: Fp3Var<P::Fp3Config>,
     pub c_rz: Fp3Var<P::Fp3Config>,

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -5,6 +5,7 @@ use ark_ec::{
 use ark_ff::{AdditiveGroup, BitIteratorBE, Field, One, PrimeField, Zero};
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 use ark_std::{borrow::Borrow, marker::PhantomData, ops::Mul};
+use educe::Educe;
 use non_zero_affine::NonZeroAffineVar;
 
 use crate::{
@@ -42,8 +43,8 @@ type BasePrimeField<P> = <<P as CurveConfig>::BaseField as Field>::BasePrimeFiel
 /// An implementation of arithmetic for Short Weierstrass curves that relies on
 /// the complete formulae derived in the paper of
 /// [[Renes, Costello, Batina 2015]](<https://eprint.iacr.org/2015/1060>).
-#[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct ProjectiveVar<P: SWCurveConfig, F: FieldVar<P::BaseField, BasePrimeField<P>>>
 where
@@ -55,13 +56,13 @@ where
     pub y: F,
     /// The z-coordinate.
     pub z: F,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 
 /// An affine representation of a curve point.
-#[derive(Derivative)]
-#[derivative(Debug(bound = "F: ark_std::fmt::Debug"), Clone(bound = "F: Clone"))]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct AffineVar<P: SWCurveConfig, F: FieldVar<P::BaseField, BasePrimeField<P>>>
 where
@@ -73,7 +74,7 @@ where
     pub y: F,
     /// Is `self` the point at infinity.
     pub infinity: Boolean<BasePrimeField<P>>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -4,8 +4,8 @@ use ark_std::ops::Add;
 
 /// An affine representation of a prime order curve point that is guaranteed
 /// to *not* be the point at infinity.
-#[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct NonZeroAffineVar<
     P: SWCurveConfig,
@@ -17,7 +17,7 @@ pub struct NonZeroAffineVar<
     pub x: F,
     /// The y-coordinate.
     pub y: F,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 
 use crate::fields::fp::FpVar;
 use ark_std::{borrow::Borrow, marker::PhantomData, ops::Mul};
+use educe::Educe;
 
 type BasePrimeField<P> = <<P as CurveConfig>::BaseField as Field>::BasePrimeField;
 
@@ -26,8 +27,8 @@ type BasePrimeField<P> = <<P as CurveConfig>::BaseField as Field>::BasePrimeFiel
 ///
 /// This is intended for use primarily for implementing efficient
 /// multi-scalar-multiplication in the Bowe-Hopwood-Pedersen hash.
-#[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct MontgomeryAffineVar<P: TECurveConfig, F: FieldVar<P::BaseField, BasePrimeField<P>>>
 where
@@ -37,7 +38,7 @@ where
     pub x: F,
     /// The y-coordinate.
     pub y: F,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 
@@ -233,8 +234,8 @@ mod montgomery_affine_impl {
 /// An implementation of arithmetic for Twisted Edwards curves that relies on
 /// the complete formulae for the affine model, as outlined in the
 /// [EFD](https://www.hyperelliptic.org/EFD/g1p/auto-twisted.html).
-#[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 #[must_use]
 pub struct AffineVar<P: TECurveConfig, F: FieldVar<P::BaseField, BasePrimeField<P>>>
 where
@@ -244,7 +245,7 @@ where
     pub x: F,
     /// The y-coordinate.
     pub y: F,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     _params: PhantomData<P>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,6 @@ extern crate ark_ff;
 #[macro_use]
 extern crate ark_relations;
 
-#[doc(hidden)]
-#[macro_use]
-extern crate derivative;
-
 /// Some utility macros for making downstream impls easier.
 #[macro_use]
 pub mod macros;


### PR DESCRIPTION
## Description

Same as a related PR in algebra: https://github.com/arkworks-rs/algebra/pull/832

There are some side effects of the `derivative` crate due to it being in a very old Rust edition. This PR replaces derivative with a popular alternative, educe. 

It also appears that educe simplifies some derivations.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
