### PR TITLE
Remove dependency on ark-relations/std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ### Improvements
 
+- [\#147](https://github.com/arkworks-rs/r1cs-std/pull/147) Remove dependency on
+  `ark-relations/std`.
+
 ### Bug Fixes
 
 ## 0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ark-bn254 = { version = "0.4.0", features = ["curve"], default-features = false 
 
 [features]
 default = ["std"]
-std = [ "ark-ff/std", "ark-relations/std", "ark-std/std", "num-bigint/std" ]
+std = [ "ark-ff/std", "ark-std/std", "num-bigint/std" ]
 parallel = [ "std", "ark-ff/parallel", "ark-std/parallel"]
 
 [[bench]]


### PR DESCRIPTION
## Description

The dependency on `ark-relations/std` is entirely unneeded.
Currently it adds some dependency dead weight for us due to pulling an outdated version of tracing-subscriber (https://github.com/arkworks-rs/snark/issues/356).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
