### PR TITLE
Fix panic issues during in-circuit polynomial interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - [\#145](https://github.com/arkworks-rs/r1cs-std/pull/145)
     - Avoid deeply nested `LinearCombinations` in `EvaluationsVar::interpolate_and_evaluate` to fix the stack overflow issue when calling `.value()` on the evaluation result.
+- [\#148](https://github.com/arkworks-rs/r1cs-std/pull/148)
+    -  Fix panic issues during in-circuit polynomial interpolation.
 
 ## 0.4.0
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently, running `EvaluationsVar::interpolate_and_evaluate` during trusted setup (i.e., when the mode of `cs` is `SynthesisMode::Setup`) will panic, because the method internally obtains the value of an in-circuit variable by calling `.value().unwrap()`, but `.value()` always returns `None` during trusted setup.

This PR fixes this issue by replacing `.value().unwrap()` with `.value().unwrap_or_default()`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (N/A)
- [ ] Updated relevant documentation in the code (N/A)
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
