### PR TITLE
Update Links in Documentation

### DIFF
--- a/src/boolean/cmp.rs
+++ b/src/boolean/cmp.rs
@@ -16,7 +16,7 @@ impl<F: PrimeField> CmpGadget<F> for Boolean<F> {
 }
 
 impl<F: PrimeField> Boolean<F> {
-    /// Enforces that `bits`, when interpreted as a integer, is less than
+    /// Enforces that `bits`, when interpreted as an integer, is less than
     /// `F::characteristic()`, That is, interpret bits as a little-endian
     /// integer, and enforce that this integer is "in the field Z_p", where
     /// `p = F::characteristic()` .

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -218,7 +218,7 @@ pub trait FieldVar<F: Field, ConstraintF: PrimeField>:
         Ok(res)
     }
 
-    /// Computes `self^S`, where S is interpreted as an little-endian
+    /// Computes `self^S`, where S is interpreted as a little-endian
     /// u64-decomposition of an integer.
     fn pow_by_constant<S: AsRef<[u64]>>(&self, exp: S) -> Result<Self, SynthesisError> {
         let mut res = Self::one();

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -247,7 +247,7 @@ where
         // step(s) of the algorithm
         //
         // Adapted from code in
-        // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs
+        // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/tests/projective.rs
         let three_b = P::COEFF_B.double() + &P::COEFF_B;
         let (x1, y1, z1) = (&self.x, &self.y, &self.z);
         let (x2, y2) = (&other.x, &other.y);
@@ -460,7 +460,7 @@ where
         // step(s) of the algorithm
         //
         // Adapted from code in
-        // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs
+        // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/tests/projective.rs
         let three_b = P::COEFF_B.double() + &P::COEFF_B;
 
         let xx = self.x.square()?; // 1
@@ -637,7 +637,7 @@ impl_bounded_ops!(
             // step(s) of the algorithm
             //
             // Adapted from code in
-            // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/src/arithmetic/projective.rs
+            // https://github.com/RustCrypto/elliptic-curves/blob/master/p256/tests/projective.rs
             let three_b = P::COEFF_B.double() + &P::COEFF_B;
             let (x1, y1, z1) = (&this.x, &this.y, &this.z);
             let (x2, y2, z2) = (&other.x, &other.y, &other.z);


### PR DESCRIPTION
1. **Link Updates in `mod.rs`**:  
   - Replaced outdated links to `p256/src/arithmetic/projective.rs` with updated links pointing to `p256/tests/projective.rs` in `RustCrypto/elliptic-curves`.  

2. **Typographical Error Fixes**:  
   - Corrected the usage of "a" to "an" in `cmp.rs` to adhere to proper grammar rules.  
   - Updated "an little-endian" to "a little-endian" in `mod.rs` to ensure grammatical accuracy.  

### **Checklist**  

- [x] Targeted PR against the correct branch (master).  
- [x] Linked to GitHub issue with discussion or provided an explanation for the updates.  
- [x] Verified grammar changes for accuracy.  
- [x] Ensured updated links lead to the correct resources.  
- [x] Reviewed changes in the "Files changed" section.  