### PR TITLE
Fix panic in `impl Sum for FpVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfixes
 
+- [\#156](https://github.com/arkworks-rs/r1cs-std/pull/156) Fix panic in `impl Sum for FpVar`
+
 ## v0.5.0
 
 ### Breaking changes

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -160,6 +160,10 @@ impl<F: PrimeField> AllocatedFp<F> {
     ///
     /// This does not create any constraints and only creates one linear
     /// combination.
+    ///
+    /// # Panics
+    ///
+    /// Panics if you pass an empty iterator.
     pub fn add_many<B: Borrow<Self>, I: Iterator<Item = B>>(iter: I) -> Self {
         let mut cs = ConstraintSystemRef::None;
         let mut has_value = true;
@@ -1090,32 +1094,42 @@ impl<F: PrimeField> AllocVar<F, F> for FpVar<F> {
 impl<'a, F: PrimeField> Sum<&'a FpVar<F>> for FpVar<F> {
     fn sum<I: Iterator<Item = &'a FpVar<F>>>(iter: I) -> FpVar<F> {
         let mut sum_constants = F::zero();
-        let sum_variables = FpVar::Var(AllocatedFp::<F>::add_many(iter.filter_map(|x| match x {
-            FpVar::Constant(c) => {
-                sum_constants += c;
-                None
-            },
-            FpVar::Var(v) => Some(v),
-        })));
-
-        let sum = sum_variables + sum_constants;
-        sum
+        let variables: Vec<_> = iter
+            .filter_map(|x| match x {
+                FpVar::Constant(c) => {
+                    sum_constants += c;
+                    None
+                },
+                FpVar::Var(v) => Some(v),
+            })
+            .collect();
+        // Can't use `AllocatedFp::add_many` with an empty iterator: it panics.
+        if variables.is_empty() {
+            return FpVar::Constant(sum_constants);
+        }
+        let sum_variables = FpVar::Var(AllocatedFp::<F>::add_many(variables.into_iter()));
+        sum_variables + sum_constants
     }
 }
 
 impl<'a, F: PrimeField> Sum<FpVar<F>> for FpVar<F> {
     fn sum<I: Iterator<Item = FpVar<F>>>(iter: I) -> FpVar<F> {
         let mut sum_constants = F::zero();
-        let sum_variables = FpVar::Var(AllocatedFp::<F>::add_many(iter.filter_map(|x| match x {
-            FpVar::Constant(c) => {
-                sum_constants += c;
-                None
-            },
-            FpVar::Var(v) => Some(v),
-        })));
-
-        let sum = sum_variables + sum_constants;
-        sum
+        let variables: Vec<_> = iter
+            .filter_map(|x| match x {
+                FpVar::Constant(c) => {
+                    sum_constants += c;
+                    None
+                },
+                FpVar::Var(v) => Some(v),
+            })
+            .collect();
+        // Can't use `AllocatedFp::add_many` with an empty iterator: it panics.
+        if variables.is_empty() {
+            return FpVar::Constant(sum_constants);
+        }
+        let sum_variables = FpVar::Var(AllocatedFp::<F>::add_many(variables.into_iter()));
+        sum_variables + sum_constants
     }
 }
 


### PR DESCRIPTION
`AllocatedFp::add_many` must not be called with an empty iterator.

CC #151

This fixes a bug for our project depending on the `ark-*` libraries that surfaced when trying to upgrade to 0.5.0.

I also looked at whether one could make `AllocatedFp::add_many` not panic in the empty case, but that wasn't as straightforward as many operations on `AllocatedFp` depend on there being a constraint system reference.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] ~~Linked to Github issue with discussion and accepted design OR~~ have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code: not really applicable, added some docs to `AllocatedFp::add_many` though
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
