### PR TITLE
fix: incorrect calc of surfeit related value

### DIFF
--- a/src/fields/emulated_fp/allocated_field_var.rs
+++ b/src/fields/emulated_fp/allocated_field_var.rs
@@ -242,12 +242,17 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedEmulatedFpVar<TargetF, Bas
             }
         }
 
+        let padding_bit_len = {
+            let mut one = BaseF::ONE.into_bigint();
+            one <<= surfeit as u32;
+            BaseF::from(one)
+        };
         let result = AllocatedEmulatedFpVar::<TargetF, BaseF> {
             cs: self.cs(),
             limbs,
-            num_of_additions_over_normal_form: self.num_of_additions_over_normal_form
-                + (other.num_of_additions_over_normal_form + BaseF::one())
-                + (other.num_of_additions_over_normal_form + BaseF::one()),
+            num_of_additions_over_normal_form: self.num_of_additions_over_normal_form // this_limb
+                + padding_bit_len // pad_non_top_limb / pad_top_limb
+                + BaseF::one(), // pad_to_kp_limb
             is_in_the_normal_form: false,
             target_phantom: PhantomData,
         };
@@ -428,9 +433,19 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedEmulatedFpVar<TargetF, Bas
         Ok(AllocatedMulResultVar {
             cs: self.cs(),
             limbs: prod_limbs,
+            // New number is upper bounded by:
+            //
+            // (a+1)2^{bits_per_limb} * (b+1)2^{bits_per_limb} * m = (ab+a+b+1)*m*2^{2*bits_per_limb}
+            //
+            // where `a = self_reduced.num_of_additions_over_normal_form` and
+            //       `b = other_reduced.num_of_additions_over_normal_form`
+            // - why m pair: at cell m, there are m possible pairs (one limb from each var) that can add to cell m
+            //
+            // In theory, we can let `prod_of_num_of_additions = (m(ab+a+b+1)-1)`. But below, we use an overestimation.
             prod_of_num_of_additions: (self_reduced.num_of_additions_over_normal_form
                 + BaseF::one())
-                * (other_reduced.num_of_additions_over_normal_form + BaseF::one()),
+                * (other_reduced.num_of_additions_over_normal_form + BaseF::one())
+                * BaseF::from((params.num_limbs) as u32),
             target_phantom: PhantomData,
         })
     }
@@ -464,13 +479,6 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedEmulatedFpVar<TargetF, Bas
         for limb in p_representations.iter() {
             p_gadget_limbs.push(FpVar::<BaseF>::Constant(*limb));
         }
-        let p_gadget = AllocatedEmulatedFpVar::<TargetF, BaseF> {
-            cs: self.cs(),
-            limbs: p_gadget_limbs,
-            num_of_additions_over_normal_form: BaseF::one(),
-            is_in_the_normal_form: false,
-            target_phantom: PhantomData,
-        };
 
         // Get delta = self - other
         let cs = self.cs().or(other.cs()).or(should_enforce.cs());
@@ -494,7 +502,7 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedEmulatedFpVar<TargetF, Bas
 
         // Compute k * p
         let mut kp_gadget_limbs = Vec::new();
-        for limb in p_gadget.limbs.iter() {
+        for limb in p_gadget_limbs.iter() {
             kp_gadget_limbs.push(limb * &k_gadget);
         }
 
@@ -914,5 +922,70 @@ impl<TargetF: PrimeField, BaseF: PrimeField> Clone for AllocatedEmulatedFpVar<Ta
             is_in_the_normal_form: self.is_in_the_normal_form,
             target_phantom: PhantomData,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_ec::{bls12::Bls12Config, pairing::Pairing};
+    use ark_relations::r1cs::ConstraintSystem;
+
+    use crate::{
+        alloc::AllocVar,
+        fields::{
+            emulated_fp::{test::check_constraint, AllocatedEmulatedFpVar},
+            fp::FpVar,
+        },
+    };
+
+    #[test]
+    fn pr_157_sub() {
+        type TargetF = <ark_bls12_381::Config as Bls12Config>::Fp;
+        type BaseF = <ark_bls12_377::Bls12_377 as Pairing>::ScalarField;
+
+        let self_limb_values = [
+            100, 2618, 1428, 2152, 2602, 1242, 2823, 511, 1752, 2058, 3599, 1113, 3207, 3601, 2736,
+            435, 1108, 2965, 2685, 1705, 1016, 1343, 1760, 2039, 1355, 1767, 2355, 1945, 3594,
+            4066, 1913, 2646,
+        ];
+        let self_num_of_additions_over_normal_form = 1;
+        let self_is_in_the_normal_form = false;
+        let other_limb_values = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 4,
+        ];
+        let other_num_of_additions_over_normal_form = 1;
+        let other_is_in_the_normal_form = false;
+
+        let cs = ConstraintSystem::new_ref();
+
+        let left_limb = self_limb_values
+            .iter()
+            .map(|v| FpVar::new_input(cs.clone(), || Ok(BaseF::from(*v))).unwrap())
+            .collect();
+        let left: AllocatedEmulatedFpVar<TargetF, BaseF> = AllocatedEmulatedFpVar {
+            cs: cs.clone(),
+            limbs: left_limb,
+            num_of_additions_over_normal_form: BaseF::from(self_num_of_additions_over_normal_form),
+            is_in_the_normal_form: self_is_in_the_normal_form,
+            target_phantom: std::marker::PhantomData,
+        };
+
+        let other_limb = other_limb_values
+            .iter()
+            .map(|v| FpVar::new_input(cs.clone(), || Ok(BaseF::from(*v))).unwrap())
+            .collect();
+        let right: AllocatedEmulatedFpVar<TargetF, BaseF> = AllocatedEmulatedFpVar {
+            cs: cs.clone(),
+            limbs: other_limb,
+            num_of_additions_over_normal_form: BaseF::from(other_num_of_additions_over_normal_form),
+            is_in_the_normal_form: other_is_in_the_normal_form,
+            target_phantom: std::marker::PhantomData,
+        };
+
+        let result = left.sub_without_reduce(&right).unwrap();
+        assert!(check_constraint(&left));
+        assert!(check_constraint(&right));
+        assert!(check_constraint(&result));
     }
 }

--- a/src/fields/emulated_fp/allocated_mul_result.rs
+++ b/src/fields/emulated_fp/allocated_mul_result.rs
@@ -113,7 +113,7 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedMulResultVar<TargetF, Base
         };
 
         // Step 2: compute surfeit
-        let surfeit = overhead!(self.prod_of_num_of_additions + BaseF::one()) + 1 + 1;
+        let surfeit = overhead!(self.prod_of_num_of_additions + BaseF::one());
 
         // Step 3: allocate k
         let k_bits = {
@@ -282,5 +282,44 @@ impl<TargetF: PrimeField, BaseF: PrimeField> AllocatedMulResultVar<TargetF, Base
             OptimizationGoal::Constraints => OptimizationType::Constraints,
             OptimizationGoal::Weight => OptimizationType::Weight,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_ec::{bls12::Bls12Config, pairing::Pairing};
+    use ark_ff::PrimeField;
+    use ark_relations::r1cs::ConstraintSystem;
+
+    use crate::{
+        alloc::AllocVar,
+        fields::emulated_fp::{
+            test::{check_constraint, check_mulres_constraint},
+            AllocatedEmulatedFpVar,
+        },
+    };
+
+    #[test]
+    fn pr_157_mul() {
+        type TargetF = <ark_bls12_381::Config as Bls12Config>::Fp;
+        type BaseF = <ark_bls12_377::Bls12_377 as Pairing>::ScalarField;
+
+        let cs = ConstraintSystem::new_ref();
+
+        let left: AllocatedEmulatedFpVar<TargetF, BaseF> =
+            AllocatedEmulatedFpVar::new_input(cs.clone(), || {
+                Ok(TargetF::from(
+                    TargetF::from(1).into_bigint()
+                        << (<TargetF as PrimeField>::MODULUS_BIT_SIZE - 1),
+                ) + TargetF::from(-1))
+            })
+            .unwrap();
+
+        let right: AllocatedEmulatedFpVar<TargetF, BaseF> = left.clone();
+
+        let result = left.mul_without_reduce(&right).unwrap();
+        assert!(check_constraint(&left));
+        assert!(check_constraint(&right));
+        assert!(check_mulres_constraint(&result));
     }
 }

--- a/src/fields/emulated_fp/mod.rs
+++ b/src/fields/emulated_fp/mod.rs
@@ -152,6 +152,7 @@ macro_rules! overhead {
         use ark_ff::BigInteger;
         let num = $x;
         let num_bits = num.into_bigint().to_bits_be();
+
         let mut skipped_bits = 0;
         for b in num_bits.iter() {
             if *b == false {
@@ -168,10 +169,13 @@ macro_rules! overhead {
             }
         }
 
-        if is_power_of_2 {
-            num_bits.len() - skipped_bits
+        // let log(0) = 0 in our case
+        if num == BaseF::zero() {
+            0
+        } else if is_power_of_2 {
+            num_bits.len() - skipped_bits - 1
         } else {
-            num_bits.len() - skipped_bits + 1
+            num_bits.len() - skipped_bits
         }
     }};
 }
@@ -200,3 +204,45 @@ pub use field_var::*;
 
 mod mul_result;
 pub use mul_result::*;
+
+#[cfg(test)]
+mod test {
+    use ark_ff::PrimeField;
+
+    use crate::{
+        fields::emulated_fp::{params::get_params, AllocatedEmulatedFpVar},
+        R1CSVar,
+    };
+
+    use super::AllocatedMulResultVar;
+
+    pub(crate) fn check_constraint<TargetF: PrimeField, BaseF: PrimeField>(
+        emulated_fpvar: &AllocatedEmulatedFpVar<TargetF, BaseF>,
+    ) -> bool {
+        let limb_values = emulated_fpvar.limbs.value().unwrap();
+        let params = get_params(
+            TargetF::MODULUS_BIT_SIZE as usize,
+            BaseF::MODULUS_BIT_SIZE as usize,
+            emulated_fpvar.get_optimization_type(),
+        );
+        let bits_per_limb = params.bits_per_limb;
+        let upper_bound = (emulated_fpvar.num_of_additions_over_normal_form + BaseF::one())
+            * (BaseF::from(BaseF::from(1).into_bigint() << bits_per_limb as u32) + BaseF::from(-1));
+        return !limb_values.iter().any(|value| value > &upper_bound);
+    }
+
+    pub(crate) fn check_mulres_constraint<TargetF: PrimeField, BaseF: PrimeField>(
+        emulated_fpvar: &AllocatedMulResultVar<TargetF, BaseF>,
+    ) -> bool {
+        let limb_values: Vec<_> = emulated_fpvar.limbs.value().unwrap();
+        let params = get_params(
+            TargetF::MODULUS_BIT_SIZE as usize,
+            BaseF::MODULUS_BIT_SIZE as usize,
+            emulated_fpvar.get_optimization_type(),
+        );
+        let bits_per_limb = params.bits_per_limb * 2;
+        let upper_bound = (emulated_fpvar.prod_of_num_of_additions + BaseF::one())
+            * (BaseF::from(BaseF::from(1).into_bigint() << bits_per_limb as u32) + BaseF::from(-1));
+        return !limb_values.iter().any(|value| value > &upper_bound);
+    }
+}


### PR DESCRIPTION
## Description

Currently, the following invariant is not maintained when computing `num_of_additions_over_normal_form` in `sub_without_reduce` and `prod_of_num_of_additions` in `mul_without_reduce`
- For `AllocatedEmulatedFpVar`, no limb has a value > (num_of_additions_over_normal_form + 1) * (2^{bits_per_limb} - 1).
- For `AllocatedMulResultVar`, no limb has a value > (prod_of_num_of_additions + 1) * (2^{bits_per_limb} - 1).

More specifically, these values are currently underestimated.

This will result in generating constraints in `group_and_check_equality` that can't be satisfied, since the `surfeit` value is used to determine how many limbs to put into a group. For example, in my overload, underestimating the `surfeit` value resulted in putting one more limb value in a group, which resulted in an overflow in `let eqn_left = left_total_limb + pad_limb + &carry_in - right_total_limb;` and made `eqn_left. conditional_enforce_equal(&eqn_right, &Boolean::<BaseF>::TRUE)` not satisfiable.

The patch also fixed the `overhead!` macro, which did not compute `ceil(log2(x))` correctly.

Since it's not easy to create test cases that will trigger the constraint system to be unsatisfied, I've just added two tests to ensure that the above invariant is satisfied. Hopefully these two test cases will also help people contribute to this part of the library in the future by documenting the invariant used throughout the implementation.

## A few more questions

1. I'm not sure why in `post_add_reduce` the reduction is only performed when `2 * params.bits_per_limb + surfeit + 1 >= BaseF::MODULUS_BIT_SIZE`. I think that checking that `params.bits_per_limb + some constant >= BaseF::MODULUS_BIT_SIZE` is sufficient. This similar pattern is also present in `sub_without_reduce`. If there is no particular reason, I think we can fix it to accurately reflect the upper bounds of the bit size.

2. Currently, the `add` and `add_constant` implementations in `AllocatedMulResultVar` don't seem to reduce the results when `prod_of_num_of_additions` is large enough. This seems to be an issue that needs to be fixed.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work. (not applicable)
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer