### PR TITLE
Fix Documentation Links and Improve Code Readability

### DIFF
--- a/src/groups/curves/mod.rs
+++ b/src/groups/curves/mod.rs
@@ -1,9 +1,9 @@
 /// This module generically implements arithmetic for Short
 /// Weierstrass elliptic curves by following the complete formulae of
-/// [[Renes, Costello, Batina 2015]](https://eprint.iacr.org/2015/1060).
+/// [[Renes, Costello, Batina 2015]](<https://eprint.iacr.org/2015/1060>).
 pub mod short_weierstrass;
 
 /// This module generically implements arithmetic for Twisted
 /// Edwards elliptic curves by following the complete formulae described in the
-/// [EFD](https://www.hyperelliptic.org/EFD/g1p/auto-twisted.html).
+/// [EFD](<https://www.hyperelliptic.org/EFD/g1p/auto-twisted.html>).
 pub mod twisted_edwards;

--- a/src/groups/curves/short_weierstrass/non_zero_affine.rs
+++ b/src/groups/curves/short_weierstrass/non_zero_affine.rs
@@ -98,7 +98,7 @@ where
     /// constraints, less than the 7 required when computing via
     /// `self.double() + other`.
     ///
-    /// This follows the formulae from [\[ELM03\]](https://arxiv.org/abs/math/0208038).
+    /// This follows the formulae from [\[ELM03\]](<https://arxiv.org/abs/math/0208038>).
     #[tracing::instrument(target = "gr1cs", skip(self))]
     pub fn double_and_add_unchecked(&self, other: &Self) -> Result<Self, SynthesisError> {
         if [self].is_constant() || other.is_constant() {


### PR DESCRIPTION
1. Fixed Documentation Links Formatting
In multiple files, we corrected markdown link formatting to use <https://...> instead of [...](). This change ensures that the documentation compiles correctly and prevents errors when generating Rust documentation.

Modified Files:
src/groups/curves/mod.rs
src/groups/curves/short_weierstrass/non_zero_affine.rs