### PR TITLE
fix: missing cs when comparing constant `FpVar`

### DIFF
--- a/src/fields/fp/cmp.rs
+++ b/src/fields/fp/cmp.rs
@@ -1,6 +1,6 @@
 use crate::{fields::fp::FpVar, prelude::*};
 use ark_ff::PrimeField;
-use ark_relations::gr1cs::{SynthesisError, Variable};
+use ark_relations::gr1cs::SynthesisError;
 use core::cmp::Ordering;
 
 impl<F: PrimeField> FpVar<F> {
@@ -139,10 +139,7 @@ impl<F: PrimeField> FpVar<F> {
     /// verify that.
     fn enforce_smaller_than_unchecked(&self, other: &FpVar<F>) -> Result<(), SynthesisError> {
         let is_smaller_than = self.is_smaller_than_unchecked(other)?;
-        let lc_one = lc!() + Variable::One;
-        [self, other]
-            .cs()
-            .enforce_r1cs_constraint(is_smaller_than.lc(), lc_one.clone(), lc_one)
+        is_smaller_than.enforce_equal(&Boolean::TRUE)
     }
 }
 


### PR DESCRIPTION
## Description

The original code used `.cs()` directly. This doesn't handle the case where `self` and `other` are constants and can lead to `SynthesisError::MissingCS`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
