### PR TITLE
Refactor UInt Shr implementation

### DIFF
--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -14,7 +14,7 @@ impl<const N: usize, T: PrimUInt, F: PrimeField> UInt<N, T, F> {
                 *a = b.clone();
             }
 
-            let value = self.value.and_then(|a| Some(a >> other));
+            let value = self.value.map(|a| a >> other);
             Ok(Self { bits, value })
         } else {
             panic!("attempt to shift right with overflow")
@@ -53,7 +53,7 @@ impl<const N: usize, T: PrimUInt, F: PrimeField, T2: PrimUInt> Shr<T2> for UInt<
     }
 }
 
-impl<'a, const N: usize, T: PrimUInt, F: PrimeField, T2: PrimUInt> Shr<T2> for &'a UInt<N, T, F> {
+impl<const N: usize, T: PrimUInt, F: PrimeField, T2: PrimUInt> Shr<T2> for &UInt<N, T, F> {
     type Output = UInt<N, T, F>;
 
     #[tracing::instrument(target = "gr1cs", skip(self, other))]


### PR DESCRIPTION
## Description

This PR addresses two Clippy warnings in the uint/shr.rs file:
Replaced Option::and_then(|x| Some(y)) with the more concise map(|x| y) pattern in the _shr_u128 method.
Removed unnecessary explicit lifetime parameter in the Shr implementation for &UInt<N, T, F>.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
