### PR TITLE
perf: use horner's method in eval dense polynomial

### DIFF
--- a/src/poly/polynomial/univariate/dense.rs
+++ b/src/poly/polynomial/univariate/dense.rs
@@ -26,16 +26,11 @@ impl<F: PrimeField> DensePolynomialVar<F> {
     /// the result. Caution for use in holographic lincheck: The output has
     /// 2 entries in one matrix
     pub fn evaluate(&self, point: &FpVar<F>) -> Result<FpVar<F>, SynthesisError> {
-        let mut result: FpVar<F> = FpVar::zero();
-        // current power of point
-        let mut curr_pow_x: FpVar<F> = FpVar::one();
-        for i in 0..self.coeffs.len() {
-            let term = &curr_pow_x * &self.coeffs[i];
-            result += &term;
-            curr_pow_x *= point;
-        }
-
-        Ok(result)
+        // Horner's Method
+        Ok(self
+            .coeffs
+            .iter()
+            .rfold(FpVar::zero(), move |acc, coeff| acc * point + coeff))
     }
 }
 


### PR DESCRIPTION
## Description

Use Horner's method to evaluate a dense polynomial. This approach reduces the number of constraints generated by half (e.g., from 20 to 10 constraints in test).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
