### PR TITLE
Use `point.is_zero()` for allocating `infinity` in `SW` curves

### DIFF
--- a/src/groups/curves/short_weierstrass/bls12/mod.rs
+++ b/src/groups/curves/short_weierstrass/bls12/mod.rs
@@ -67,7 +67,7 @@ impl<P: Bls12Config> AllocVar<G1Prepared<P>, P::Fp> for G1PreparedVar<P> {
         let y = FpVar::new_variable(ark_relations::ns!(cs, "y"), || g1_prep.map(|g| g.y), mode)?;
         let infinity = Boolean::new_variable(
             ark_relations::ns!(cs, "inf"),
-            || g1_prep.map(|g| g.infinity),
+            || g1_prep.map(|g| g.is_zero()),
             mode,
         )?;
         let g = AffineVar::new(x, y, infinity);

--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -165,7 +165,7 @@ where
             let point = self.value()?.into_affine();
             let x = F::new_constant(ConstraintSystemRef::None, point.x)?;
             let y = F::new_constant(ConstraintSystemRef::None, point.y)?;
-            let infinity = Boolean::constant(point.infinity);
+            let infinity = Boolean::constant(point.is_zero());
             Ok(AffineVar::new(x, y, infinity))
         } else {
             let cs = self.cs();


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Needed for https://github.com/arkworks-rs/algebra/pull/639, and is anyway the right thing to do.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
