### PR TITLE
fix: update broken ginger-lib reference to HorizenOfficial repository

### DIFF
--- a/src/fields/cubic_extension.rs
+++ b/src/fields/cubic_extension.rs
@@ -228,7 +228,7 @@ where
         // Devegili, OhEigeartaigh, Scott, Dahab
         //
         // This implementation adapted from
-        // https://github.com/ZencashOfficial/ginger-lib/blob/development/r1cs/gadgets/std/src/fields/fp3.rs
+        // https://github.com/HorizenOfficial/ginger-lib/blob/master/r1cs/gadgets/std/src/fields/fp3.rs
         let v0 = &self.c0 * &other.c0;
         let v1 = &self.c1 * &other.c1;
         let v2 = &self.c2 * &other.c2;


### PR DESCRIPTION
Update the reference link in cubic_extension.rs from the deprecated 
ZencashOfficial/ginger-lib repository to the current HorizenOfficial/ginger-lib 
repository. The ginger-lib project was moved when Zencash rebranded to Horizen.

- Replace broken link: https://github.com/ZencashOfficial/ginger-lib/blob/development/r1cs/gadgets/std/src/fields/fp3.rs
- With working link: https://github.com/HorizenOfficial/ginger-lib/blob/master/r1cs/gadgets/std/src/fields/fp3.rs

This fixes the reference to the original implementation that was adapted for 
the cubic extension field arithmetic in arkworks.