### PR TITLE
Avoid panic on division by zero in mul_by_inverse_unchecked

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -186,7 +186,10 @@ pub trait FieldVar<F: Field, ConstraintF: PrimeField>:
         match cs {
             // If we're in the constant case, we just allocate a new constant having value equalling
             // `self * d.inverse()`.
-            ConstraintSystemRef::None => Self::new_constant(
+            ConstraintSystemRef::None => {
+                let denom_inv = d.value()?.inverse().ok_or(SynthesisError::Unsatisfiable)?;
+                Self::new_constant(cs, self.value()? * denom_inv)
+            },
                 cs,
                 self.value()? * d.value()?.inverse().expect("division by zero"),
             ),


### PR DESCRIPTION


### Description
- **What**: Replace `expect("division by zero")` with `Err(SynthesisError::Unsatisfiable)` when `cs == ConstraintSystemRef::None` in `mul_by_inverse_unchecked`.
- **Why**: Prevents unexpected panics in library code and aligns behavior with the witness branch (which doesn’t panic).
- **Behavior change**: Constant division by zero now returns an error instead of panicking.
