### PR TITLE
chore: fix typos in comment

### DIFF
--- a/src/pairing/bls12/mod.rs
+++ b/src/pairing/bls12/mod.rs
@@ -123,7 +123,7 @@ impl<P: Bls12Config> PG<Bls12<P>> for PairingVar<P> {
             // r = f^((p^6 - 1)(p^2 + 1))
             r *= &f2;
 
-            // Hard part of the final exponentation is below:
+            // Hard part of the final exponentiation is below:
             // From https://eprint.iacr.org/2016/130.pdf, Table 1
             let mut y0 = r.cyclotomic_square()?;
             y0 = y0.unitary_inverse()?;

--- a/src/poly/polynomial/univariate/dense.rs
+++ b/src/poly/polynomial/univariate/dense.rs
@@ -4,7 +4,7 @@ use ark_std::vec::Vec;
 
 use crate::fields::{fp::FpVar, FieldVar};
 
-/// Stores a polynomial in coefficient form, where coeffcient is represented by
+/// Stores a polynomial in coefficient form, where coefficient is represented by
 /// a list of `Fpvar<F>`.
 pub struct DensePolynomialVar<F: PrimeField> {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.


### PR DESCRIPTION
## Description

Fix some typos in comment:
 - `exponentation` → `exponentiation`
 - `coeffcient` → `coefficient`