### PR TITLE
fix: subgroup check in r-check branch for TE and SW

### DIFF
--- a/src/groups/curves/short_weierstrass/mod.rs
+++ b/src/groups/curves/short_weierstrass/mod.rs
@@ -900,7 +900,7 @@ where
                 if cofactor_weight < modulus_minus_1_weight {
                     Ok(result)
                 } else {
-                    ge.enforce_equal(&ge)?;
+                    ge.negate()?.enforce_equal(&result)?;
                     Ok(ge)
                 }
             },

--- a/src/groups/curves/twisted_edwards/mod.rs
+++ b/src/groups/curves/twisted_edwards/mod.rs
@@ -641,7 +641,7 @@ where
                 if cofactor_weight < modulus_minus_1_weight {
                     Ok(result)
                 } else {
-                    ge.enforce_equal(&ge)?;
+                    ge.negate()?.enforce_equal(&result)?;
                     Ok(ge)
                 }
             },


### PR DESCRIPTION
Replace the no-op constraint in the r-check witness allocation path with a real subgroup check. For both Twisted Edwards and Short Weierstrass gadgets, enforce that (r-1)ge equals -ge by checking ge.negate() == result. This restores the intended prime-order subgroup enforcement parity with enforce_prime_order and prevents bypassing constraints.