### PR TITLE
Fix conditional equality for constant field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugfixes
 
+- [\#214](https://github.com/arkworks-rs/r1cs-std/pull/214) Enforce `FpVar` conditional equality for unequal constants
 - [\#156](https://github.com/arkworks-rs/r1cs-std/pull/156) Fix panic in `impl Sum for FpVar`
 - [\#198](https://github.com/arkworks-rs/r1cs-std/pull/198) Remove duplicate native cases in run_binary_exhaustive_both
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- [\#214](https://github.com/arkworks-rs/r1cs-std/pull/214) Enforce `FpVar` conditional equality for unequal constants
+- [\#214](https://github.com/arkworks-rs/r1cs-std/pull/214) Fix `FpVar::{enforce_equal, conditional_enforce_equal}` accepting unequal constants while enforcement is active
 - [\#156](https://github.com/arkworks-rs/r1cs-std/pull/156) Fix panic in `impl Sum for FpVar`
 - [\#198](https://github.com/arkworks-rs/r1cs-std/pull/198) Remove duplicate native cases in run_binary_exhaustive_both
 

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1423,4 +1423,26 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn conditional_equality_with_constant_operands_has_assignment_independent_shape() {
+        let synthesize = |guard_value| {
+            let cs = ConstraintSystem::new_ref();
+            let guard = Boolean::new_input(cs.clone(), || Ok(guard_value)).unwrap();
+            FpVar::Constant(Fr::zero())
+                .conditional_enforce_equal(&FpVar::Constant(Fr::from(1u64)), &guard)
+                .unwrap();
+            cs
+        };
+
+        let disabled_cs = synthesize(false);
+        let enabled_cs = synthesize(true);
+
+        assert!(disabled_cs.is_satisfied().unwrap());
+        assert!(!enabled_cs.is_satisfied().unwrap());
+        assert_eq!(
+            disabled_cs.to_matrices().unwrap(),
+            enabled_cs.to_matrices().unwrap()
+        );
+    }
 }

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1087,11 +1087,10 @@ impl<F: PrimeField> EqGadget<F> for FpVar<F> {
     ) -> Result<(), SynthesisError> {
         match (self, other) {
             (Self::Constant(c1), Self::Constant(c2)) => {
-                if c1 == c2 {
-                    Ok(())
-                } else {
-                    should_enforce.enforce_equal(&Boolean::FALSE)
+                if c1 != c2 {
+                    should_enforce.enforce_equal(&Boolean::FALSE)?;
                 }
+                Ok(())
             },
             (Self::Constant(c), Self::Var(v)) | (Self::Var(v), Self::Constant(c)) => {
                 let cs = v.cs.clone();

--- a/src/fields/fp/mod.rs
+++ b/src/fields/fp/mod.rs
@@ -1086,7 +1086,13 @@ impl<F: PrimeField> EqGadget<F> for FpVar<F> {
         should_enforce: &Boolean<F>,
     ) -> Result<(), SynthesisError> {
         match (self, other) {
-            (Self::Constant(_), Self::Constant(_)) => Ok(()),
+            (Self::Constant(c1), Self::Constant(c2)) => {
+                if c1 == c2 {
+                    Ok(())
+                } else {
+                    should_enforce.enforce_equal(&Boolean::FALSE)
+                }
+            },
             (Self::Constant(c), Self::Var(v)) | (Self::Var(v), Self::Constant(c)) => {
                 let cs = v.cs.clone();
                 let c = AllocatedFp::new_constant(cs, c)?;
@@ -1318,12 +1324,13 @@ impl<'a, F: PrimeField> Sum<FpVar<F>> for FpVar<F> {
 mod test {
     use crate::{
         alloc::AllocVar,
+        boolean::Boolean,
         eq::EqGadget,
         fields::{fp::FpVar, FieldVar},
         test_utils::{combination, modes},
         GR1CSVar,
     };
-    use ark_relations::gr1cs::ConstraintSystem;
+    use ark_relations::gr1cs::{ConstraintSystem, SynthesisError};
     use ark_std::{UniformRand, Zero};
     use ark_test_curves::bls12_381::Fr;
 
@@ -1378,6 +1385,43 @@ mod test {
 
             assert!(cs.is_satisfied().unwrap());
             assert_eq!(sum.value().unwrap(), sum_expected);
+        }
+    }
+
+    #[test]
+    fn conditional_equality_matches_implication_for_all_modes() {
+        for left_mode in modes() {
+            for right_mode in modes() {
+                for guard_mode in modes() {
+                    for values_equal in [false, true] {
+                        for guard_value in [false, true] {
+                            let cs = ConstraintSystem::new_ref();
+                            let left_value = Fr::zero();
+                            let right_value = if values_equal {
+                                left_value
+                            } else {
+                                Fr::from(1u64)
+                            };
+                            let left =
+                                FpVar::new_variable(cs.clone(), || Ok(left_value), left_mode)
+                                    .unwrap();
+                            let right =
+                                FpVar::new_variable(cs.clone(), || Ok(right_value), right_mode)
+                                    .unwrap();
+                            let guard =
+                                Boolean::new_variable(cs.clone(), || Ok(guard_value), guard_mode)
+                                    .unwrap();
+
+                            let accepted = match left.conditional_enforce_equal(&right, &guard) {
+                                Ok(()) => cs.is_satisfied().unwrap(),
+                                Err(SynthesisError::Unsatisfiable) => false,
+                                Err(error) => panic!("unexpected synthesis error: {error:?}"),
+                            };
+                            assert_eq!(accepted, !guard_value || values_equal);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

`FpVar::conditional_enforce_equal` returned success for every constant/constant pair,
without inspecting the values or the guard. Unequal constants under a true guard could
therefore bypass the documented conditional-equality implication.

Equal constants remain a no-op. Unequal constants now require the guard to be false.
The regression test exhaustively covers all 108 allocation-mode, equality, and guard
combinations against `!guard || left == right`.

Reproduction: [fork CI run 29434225152](https://github.com/1sgtpepper/r1cs-std/actions/runs/29434225152)

Validation:

- `cargo test --all --all-features`
- `cargo doc --all --no-deps --document-private-items --all-features`
- `cargo build --no-default-features --target aarch64-unknown-none`

closes: #213

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code — no public API documentation changed; this restores the existing equality contract.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
